### PR TITLE
corrected installation link and added aliases to redirect incomplete …

### DIFF
--- a/content/docs/automation/overview.md
+++ b/content/docs/automation/overview.md
@@ -1,8 +1,6 @@
 ---
 title: Pipeline Actions
 aliases:
-- "/docs/webhooks"
-- "/docs/pipeline-actions"
 - "/docs/automation"
 weight: 1
 layout: single

--- a/content/docs/automation/overview.md
+++ b/content/docs/automation/overview.md
@@ -1,7 +1,9 @@
 ---
 title: Pipeline Actions
 aliases:
-- "/docs/github-webhook"
+- "/docs/webhooks"
+- "/docs/pipeline-actions"
+- "/docs/automation"
 weight: 1
 layout: single
 publishdate: 2020-10-20 04:00:00 +0000
@@ -17,7 +19,7 @@ menu:
     weight: 1
 ---
 
-Pipeline actions allow launching of pipelines based on events. 
+Pipeline actions allow launching of pipelines based on events.
 
 Tower currently offers support for native **GitHub webhooks** and a general **Tower webhook** that can be invoked programmatically. Support for Bitbucket and GitLab are coming soon.
 

--- a/content/docs/getting-started/usage.md
+++ b/content/docs/getting-started/usage.md
@@ -40,7 +40,7 @@ To try Tower, visit [tower.nf](https://tower.nf/login) and login with GitHub or 
 <br>
 
 ## Community
-For more information on installing the Community version of Tower visit [our GitHub repository](https://github.com/seqeralabs/nf-tower) and follow our [installation guide](/docs/compute-envs).
+For more information on installing the Community version of Tower visit [our GitHub repository](https://github.com/seqeralabs/nf-tower) and follow our [installation guide](/docs/installation).
 
 {{% pretty_screenshot img="/uploads/2020/10/starting_tower_opensource.png" %}}
 

--- a/content/docs/git/git-overview.md
+++ b/content/docs/git/git-overview.md
@@ -1,7 +1,7 @@
 ---
 title: Git Overview
 aliases:
-- "/docs/overview"
+- "/docs/git"
 weight: 1
 layout: single
 publishdate: 2020-10-20 04:00:00 +0000

--- a/content/docs/installation/system-deployment.md
+++ b/content/docs/installation/system-deployment.md
@@ -1,5 +1,7 @@
 ---
 title: System deployment
+aliases:
+- "/docs/installation"
 weight: 1
 layout: single
 publishdate: 2020-10-20 04:00:00 +0000

--- a/content/docs/monitoring/overview.md
+++ b/content/docs/monitoring/overview.md
@@ -1,7 +1,7 @@
 ---
 title: Dashboard overview
 aliases:
-- "/docs/monitoring-tower-pipelines"
+- "/docs/monitoring"
 weight: 1
 layout: single
 publishdate: 2020-10-20 04:00:00 +0000
@@ -20,7 +20,7 @@ menu:
 
 ## Navigation bar
 
-Jobs have been submitted with Tower can be monitored wherever you have an internet connection. 
+Jobs have been submitted with Tower can be monitored wherever you have an internet connection.
 
 The **navigation bar** contains all previous jobs executions. Each new or resumed job will be given a random name e.g: `grave_williams`.
 
@@ -40,7 +40,7 @@ In the left bar:
 
 ## Search
 
-The search box enables searching for runs and pipelines by name. 
+The search box enables searching for runs and pipelines by name.
 
 Use asterisks `✽` before and after keyword to filter results.
 


### PR DESCRIPTION
Link fixed and aliases added to redirect parent URLs to the child URL: e.g: help.tower.nf/docs/git --> help.tower.nf/docs/git/git-overview/ . Before `help.tower.nf/docs/git` would return 404