### PR TITLE
Add nextflow asset binary warning note

### DIFF
--- a/docs/compute-envs/altair-pbs-pro.md
+++ b/docs/compute-envs/altair-pbs-pro.md
@@ -17,6 +17,9 @@ To launch pipelines into a **Altair PBS Pro** scheduler from Tower, the followin
 - The cluster queue used to run the Nextflow head job must be able to submit cluster jobs.
 - The Nextflow runtime version **21.02.0-edge** (or later) should be installed on the cluster.
 
+!!! warn 
+    Please use the self-installer binary version of Nextflow, instead of the pre-packaged binary. For example, use [nextflow self-installer script](https://github.com/nextflow-io/nextflow/releases/download/v21.04.2/nextflow) instead of [pre-packaged nextflow-VERSION-all](https://github.com/nextflow-io/nextflow/releases/download/v21.04.2/nextflow-21.04.2-all) binary.
+
 ## Compute environment
 
 Follow these steps to create a new compute environment for **Altair PBS Pro**:

--- a/docs/compute-envs/grid-engine.md
+++ b/docs/compute-envs/grid-engine.md
@@ -16,6 +16,9 @@ To launch pipelines into a **Grid engine** scheduler from Tower, the following r
 * The cluster queue used to run the Nextflow head job must be able to submit cluster jobs.
 * The Nextflow runtime version **21.02.0-edge** (or later) should be installed on the cluster.
 
+!!! warn 
+    Please use the self-installer binary version of Nextflow, instead of the pre-packaged binary. For example, use [nextflow self-installer script](https://github.com/nextflow-io/nextflow/releases/download/v21.04.2/nextflow) instead of [pre-packaged nextflow-VERSION-all](https://github.com/nextflow-io/nextflow/releases/download/v21.04.2/nextflow-21.04.2-all) binary.
+
 
 ## Compute environment
 

--- a/docs/compute-envs/lsf.md
+++ b/docs/compute-envs/lsf.md
@@ -20,6 +20,9 @@ To launch pipelines into a LSF managed cluster from Tower, the following require
 * The Nextflow runtime version **21.02.0-edge** (or later) should be installed on the cluster.
 
 
+!!! warn 
+    Please use the self-installer binary version of Nextflow, instead of the pre-packaged binary. For example, use [nextflow self-installer script](https://github.com/nextflow-io/nextflow/releases/download/v21.04.2/nextflow) instead of [pre-packaged nextflow-VERSION-all](https://github.com/nextflow-io/nextflow/releases/download/v21.04.2/nextflow-21.04.2-all) binary.
+
 ## Compute environment
 
 Follow these steps to create a new compute environment for LSF:

--- a/docs/compute-envs/slurm.md
+++ b/docs/compute-envs/slurm.md
@@ -20,6 +20,9 @@ To launch pipelines into a Slurm cluster from Tower, the following requirements 
 * The Nextflow runtime version **21.02.0-edge** (or later) should be installed on the cluster.
 
 
+!!! warn 
+    Please use the self-installer binary version of Nextflow, instead of the pre-packaged binary. For example, use [nextflow self-installer script](https://github.com/nextflow-io/nextflow/releases/download/v21.04.2/nextflow) instead of [pre-packaged nextflow-VERSION-all](https://github.com/nextflow-io/nextflow/releases/download/v21.04.2/nextflow-21.04.2-all) binary.
+
 ## Compute environment
 
 Follow these steps to create a new compute environment for Slurm:


### PR DESCRIPTION
This PR closes #89  by adding a warning in the grid cluster executors regarding the right nextflow binary distribution.





<img width="1038" alt="image" src="https://user-images.githubusercontent.com/12799326/126172384-0088e3cd-6b28-44b3-85a5-548a4ea34681.png">
