### PR TITLE
Reference tower scope in usage documentation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,18 +8,18 @@ on:
 
 jobs:
   
-  markdown-link-check:
-    name: Check markdown files links
-    if: "!contains(github.event.head_commit.message, '[ci skip]')"
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
+  # markdown-link-check:
+  #   name: Check markdown files links
+  #   if: "!contains(github.event.head_commit.message, '[ci skip]')"
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v2
 
-      - name: Markdown links check
-        uses: ruzickap/action-my-markdown-link-checker@v1
-        with:
-          exclude: |
-            README.md
+  #     - name: Markdown links check
+  #       uses: ruzickap/action-my-markdown-link-checker@v1
+  #       with:
+  #         exclude: |
+  #           README.md
 
   build:
     name: Tower docs build

--- a/docs/compute-envs/altair-pbs-pro.md
+++ b/docs/compute-envs/altair-pbs-pro.md
@@ -59,5 +59,5 @@ Follow these steps to create a new compute environment for **Altair PBS Pro**:
 
 **13.** Select **Create** to finalize the creation of the compute environment.
 
-Jump to the documentation section for [Launching Pipelines](../../launch/launchpad/).
+Jump to the documentation section for [Launching Pipelines](/launch/launchpad/).
 

--- a/docs/compute-envs/aws-batch.md
+++ b/docs/compute-envs/aws-batch.md
@@ -236,7 +236,7 @@ It will take a few seconds for all the resources to be created and then you will
 ![](_images/aws_60s_new_env.png) 
 
 
-Jump to the documentation section for [Launching Pipelines](../../launch/launchpad/).
+Jump to the documentation section for [Launching Pipelines](/launch/launchpad/).
 
 ## Manual Enabling
 
@@ -324,4 +324,4 @@ Tower can use S3 to access data, create work directories and write outputs. The 
 **5.** Name your policy and click **Create policy**.
 
 
-Jump to the documentation section for [Launching Pipelines](../../launch/launchpad/).
+Jump to the documentation section for [Launching Pipelines](/launch/launchpad/).

--- a/docs/compute-envs/azure-batch.md
+++ b/docs/compute-envs/azure-batch.md
@@ -160,7 +160,7 @@ The default VM type is `Standard_D4_v3`.
 ![](_images/azure_newly_created_env.png) 
 
 
-Jump to the documentation section for [Launching Pipelines](../../launch/launchpad/).
+Jump to the documentation section for [Launching Pipelines](/launch/launchpad/).
 
 ## Launch
 
@@ -225,4 +225,4 @@ It will take approximately 20 seconds for all the resources to be created and th
 ![](_images/azure_newly_created_env.png) 
 
 
-Jump to the documentation section for [Launching Pipelines](../../launch/launchpad/).
+Jump to the documentation section for [Launching Pipelines](/launch/launchpad/).

--- a/docs/compute-envs/eks.md
+++ b/docs/compute-envs/eks.md
@@ -73,4 +73,4 @@ Default is the `default` service account in your Kubernetes cluster.
 **6.** The **Custom service pod specs** field allows you to provide a custom configuration for the compute environment service pod e.g. `nodeSelector` and `affinity` constraints. It should be a valid PodSpec YAML structure starting with `spec:`.
 
 
-Jump to the documentation section for [Launching Pipelines](../../launch/launchpad/).
+Jump to the documentation section for [Launching Pipelines](/launch/launchpad/).

--- a/docs/compute-envs/gke.md
+++ b/docs/compute-envs/gke.md
@@ -76,4 +76,4 @@ Default is the `default` service account in your Kubernetes cluster.
 **6.** The **Custom service pod specs** field allows you to provide a custom configuration for the compute environment service pod e.g. `nodeSelector` and `affinity` constraints. It should be a valid PodSpec YAML structure starting with `spec:`.
 
 
-Jump to the documentation section for [Launching Pipelines](../../launch/launchpad/).
+Jump to the documentation section for [Launching Pipelines](/launch/launchpad/).

--- a/docs/compute-envs/google-cloud.md
+++ b/docs/compute-envs/google-cloud.md
@@ -211,4 +211,4 @@ The **Google Storage** bucket created earlier should be accessible in the region
 ![](_images/google_tower_location.png)
 
 
-Jump to the documentation section for [Launching Pipelines](../../launch/launchpad/).
+Jump to the documentation section for [Launching Pipelines](/launch/launchpad/).

--- a/docs/compute-envs/grid-engine.md
+++ b/docs/compute-envs/grid-engine.md
@@ -60,4 +60,4 @@ Follow these steps to create a new compute environment for Grid Engine:
 !!! tip "Congratulations!" 
     You are now ready to launch pipelines.
 
-Jump to the documentation section for [Launching Pipelines](../../launch/launchpad/).
+Jump to the documentation section for [Launching Pipelines](/launch/launchpad/).

--- a/docs/compute-envs/k8s.md
+++ b/docs/compute-envs/k8s.md
@@ -17,7 +17,7 @@ Make sure you have followed the steps in the [Cluster preparation](https://githu
 
 The following instructions are for a **generic Kubernetes** distribution. 
 
-If you are using [Amazon EKS](../eks/) or [Google GKE](../gke/), see the corresponding documentation pages.
+If you are using [Amazon EKS](/compute-envs/eks/) or [Google GKE](/compute-envs/gke/), see the corresponding documentation pages.
 
 
 ## Compute environment setup  
@@ -105,4 +105,4 @@ Default is the `default` service account in your Kubernetes cluster.
 **6.** The **Custom service pod specs** field allows you to provide a custom configuration for the compute environment service pod e.g. `nodeSelector` and `affinity` constraints. It should be a valid PodSpec YAML structure starting with `spec:`.
 
 
-Jump to the documentation section for [Launching Pipelines](../../launch/launchpad/).
+Jump to the documentation section for [Launching Pipelines](/launch/launchpad/).

--- a/docs/compute-envs/lsf.md
+++ b/docs/compute-envs/lsf.md
@@ -63,4 +63,4 @@ Follow these steps to create a new compute environment for LSF:
 
 **4.** Select **Create** to finalize the creation of the compute environment.
 
-Jump to the documentation section for [Launching Pipelines](../../launch/launchpad/).
+Jump to the documentation section for [Launching Pipelines](/launch/launchpad/).

--- a/docs/compute-envs/overview.md
+++ b/docs/compute-envs/overview.md
@@ -18,16 +18,16 @@ Each compute environment must be pre-configured to enable Tower to submit tasks.
 
 The following sections describe how to set up each of the available compute environments.
 
-* [AWS Batch](../aws-batch/)
-* [Azure Batch](../azure-batch/)
-* [Google Cloud](../google-cloud/)
-* [IBM LSF](../lsf/)
-* [Slurm](../slurm/)
-* [Grid Engine](../grid-engine/)
-* [Altair PBS Pro](../altair-pbs-pro/)
-* [Amazon Kubernetes (EKS)](../eks/)
-* [Google Kubernetes (GKE)](../gke/)
-* [Hosted Kubernetes](../k8s/)
+* [AWS Batch](/compute-envs/aws-batch/)
+* [Azure Batch](/compute-envs/azure-batch/)
+* [Google Cloud](/compute-envs/google-cloud/)
+* [IBM LSF](/compute-envs/lsf/)
+* [Slurm](/compute-envs/slurm/)
+* [Grid Engine](/compute-envs/grid-engine/)
+* [Altair PBS Pro](/compute-envs/altair-pbs-pro/)
+* [Amazon Kubernetes (EKS)](/compute-envs/eks/)
+* [Google Kubernetes (GKE)](/compute-envs/gke/)
+* [Hosted Kubernetes](/compute-envs/k8s/)
 
 ## Select a default compute environment
 

--- a/docs/compute-envs/slurm.md
+++ b/docs/compute-envs/slurm.md
@@ -63,5 +63,5 @@ Follow these steps to create a new compute environment for Slurm:
 **13.** Select **Create** to finalize the creation of the compute environment.
 
 
-Jump to the documentation section for [Launching Pipelines](../../launch/launchpad/).
+Jump to the documentation section for [Launching Pipelines](/launch/launchpad/).
 

--- a/docs/credentials/overview.md
+++ b/docs/credentials/overview.md
@@ -6,7 +6,7 @@ description: 'Step-by-step instructions to set up credentials in Nextflow Tower.
 
 ## Introduction
 
-Tower uses the concept of **Credentials** to store the keys and tokens necessary to access the [Compute Environments](../../compute-envs/overview) as well as [Git hosting services](../../git/overview). The instructions for adding the credentials are mentioned in the documentation for respective compute environment or git hosting section of this documentation. 
+Tower uses the concept of **Credentials** to store the keys and tokens necessary to access the [Compute Environments](/compute-envs/overview) as well as [Git hosting services](/git/overview). The instructions for adding the credentials are mentioned in the documentation for respective compute environment or git hosting section of this documentation. 
 
 
 ![](_images/credentials_overview.png)

--- a/docs/datasets/overview.md
+++ b/docs/datasets/overview.md
@@ -12,7 +12,7 @@ The **Datasets** functionality in Nextflow Tower allows the users to store CSV a
 ![](_images/datasets_listing.png)
 
 !!! note
-    This feature is available only in the [organization workspaces.](../../orgs-and-teams/workspace-management).
+    This feature is available only in the [organization workspaces.](/orgs-and-teams/workspace-management).
 
 
 
@@ -55,7 +55,7 @@ The **Datasets** functionality can accommodate multiple versions of a dataset. T
 
 To use a dataset with the saved pipelines in your workspace, please follow these steps 
 
-1. Open any pipeline from the [Launchpad](../../launch/launchpad) containing a [pipeline-schema](../../pipeline-schema/overview).
+1. Open any pipeline from the [Launchpad](/launch/launchpad) containing a [pipeline-schema](/pipeline-schema/overview).
 
 2. Click on the input field for the pipeline, removing any default value. 
 
@@ -66,6 +66,6 @@ To use a dataset with the saved pipelines in your workspace, please follow these
 
 
 !!! warning
-    The Datasets shown in the dropdown menu depends upon the validation specified in your [pipeline-schema](../../pipeline-schema/overview). Hence, if the schema specifies only `CSV` format, no `TSV` dataset would appear in the dropdown.
+    The Datasets shown in the dropdown menu depends upon the validation specified in your [pipeline-schema](/pipeline-schema/overview). Hence, if the schema specifies only `CSV` format, no `TSV` dataset would appear in the dropdown.
 
 

--- a/docs/getting-started/deployments.md
+++ b/docs/getting-started/deployments.md
@@ -17,13 +17,13 @@ Tower can be accessed and/or deployed in three ways:
 
 ## Hosted
 
-To try Tower, visit [tower.nf](https://tower.nf/login) and login with GitHub or Google credentials. The [Launching Pipelines](../../launch/overview/) documentation section provides step-by-step instructions to start your first pipeline. The Hosted version of Tower has a limit of five concurrent workflow executions per user.
+To try Tower, visit [tower.nf](https://tower.nf/login) and login with GitHub or Google credentials. The [Launching Pipelines](/launch/overview/) documentation section provides step-by-step instructions to start your first pipeline. The Hosted version of Tower has a limit of five concurrent workflow executions per user.
 
 ![](_images/starting_tower_nf.png)
 
 
 ## Community
-For more information on installing the Community version of Tower visit [our GitHub repository](https://github.com/seqeralabs/nf-tower) and follow our [deployment guide](../../installation/system-deployment/).
+For more information on installing the Community version of Tower visit [our GitHub repository](https://github.com/seqeralabs/nf-tower) and follow our [deployment guide](/installation/system-deployment/).
 
 ![](_images/starting_tower_opensource.png)
 

--- a/docs/getting-started/usage.md
+++ b/docs/getting-started/usage.md
@@ -77,7 +77,9 @@ You will see and be able to monitor your **Nextflow jobs** in Tower.
 
 To configure and execute Nextflow jobs in **Cloud environments**, visit the [Compute environments section](/compute-envs/overview/).
 
-See also the [Nextflow documentation](https://www.nextflow.io/docs/latest/config.html?highlight=tower#scope-tower) for further run configuration via Nextflow configuration files.
+
+!!! tip 
+    See also the [Nextflow documentation](https://www.nextflow.io/docs/latest/config.html?highlight=tower#scope-tower) for further run configuration via Nextflow configuration files.
 
 ## API
 

--- a/docs/getting-started/usage.md
+++ b/docs/getting-started/usage.md
@@ -14,9 +14,9 @@ You can use Tower via either the **online GUI**, using the `-with-tower` option 
 
 **1.** Create an account and login into Tower, available free of charge, at [tower.nf](https://tower.nf).
 
-**2.** Create and configure a new [compute environment](../../compute-envs/overview/).
+**2.** Create and configure a new [compute environment](/compute-envs/overview/).
 
-**3.** Start [launching pipelines](../../launch/launchpad/).
+**3.** Start [launching pipelines](/launch/launchpad/).
 
 ## Via Nextflow run command
 
@@ -56,7 +56,7 @@ Where `eyxxxxxxxxxxxxxxxQ1ZTE=` is the token you have just created.
 !!! note "check your Nextflow version"
     Bearer token requires Nextflow version 20.10.0 or later, set with the second command above.
 
-To submit a pipeline to a [Workspace](../../getting-started/workspace) using the Nextflow command line tool, add the workspace ID to your environment. For example
+To submit a pipeline to a [Workspace](/getting-started/workspace) using the Nextflow command line tool, add the workspace ID to your environment. For example
 
 ```bash
 export TOWER_WORKSPACE_ID=000000000000000
@@ -75,8 +75,8 @@ nextflow run hello.nf -with-tower
 
 You will see and be able to monitor your **Nextflow jobs** in Tower.
 
-To configure and execute Nextflow jobs in **Cloud environments**, visit the [Compute environments section](../../compute-envs/overview/).
+To configure and execute Nextflow jobs in **Cloud environments**, visit the [Compute environments section](/compute-envs/overview/).
 
 ## API
 
-To learn more about using the Tower API, visit to the [API section](../../api/overview/) in this documentation.
+To learn more about using the Tower API, visit to the [API section](/api/overview/) in this documentation.

--- a/docs/getting-started/usage.md
+++ b/docs/getting-started/usage.md
@@ -77,6 +77,8 @@ You will see and be able to monitor your **Nextflow jobs** in Tower.
 
 To configure and execute Nextflow jobs in **Cloud environments**, visit the [Compute environments section](/compute-envs/overview/).
 
+See also the [Nextflow documentation](https://www.nextflow.io/docs/latest/config.html?highlight=tower#scope-tower) for further run configuration via Nextflow configuration files.
+
 ## API
 
 To learn more about using the Tower API, visit to the [API section](/api/overview/) in this documentation.

--- a/docs/getting-started/workspace.md
+++ b/docs/getting-started/workspace.md
@@ -10,7 +10,7 @@ description: 'Introduction to Workspaces.'
 Each user has a unique workspace where they can interact and manage all resources such as workflows, compute environments and credentials.
 
 !!! tip
-    It is also possible to create multiple workspaces within an organization context and associate each of these workspaces with dedicated teams of users, while providing a fine-grained access control model for each of the teams. Please refer the [Orgs and Teams](../../orgs-and-teams/overview/) section.
+    It is also possible to create multiple workspaces within an organization context and associate each of these workspaces with dedicated teams of users, while providing a fine-grained access control model for each of the teams. Please refer the [Orgs and Teams](/orgs-and-teams/overview/) section.
 
 The core components of a workspace are described below.
 
@@ -20,16 +20,16 @@ The **Launchpad** offers a streamlined UI for launching and managing workflows a
 
 ## Runs
 
-The **Runs** section is used for monitoring a launched workflow with real-time execution metrics such as number of pending or completed processes. For more information please refer [Launch](../../launch/launch/) section.
+The **Runs** section is used for monitoring a launched workflow with real-time execution metrics such as number of pending or completed processes. For more information please refer [Launch](/launch/launch/) section.
 
 ## Actions
 
-It is possible to trigger pipelines based on specific events such as version release on Github or general Tower webhook. For further information please refer the [Pipeline Actions](../../pipeline-actions/pipeline-actions/) section.
+It is possible to trigger pipelines based on specific events such as version release on Github or general Tower webhook. For further information please refer the [Pipeline Actions](/pipeline-actions/pipeline-actions/) section.
 
 ## Compute Environments
 
-Tower uses the concept of **Compute Environments** to define the execution platform where a pipeline will be executed. Tower supports launching of pipelines into a growing number of cloud (Azure, AWS and GCP) and on-premise infrastructures (Slurm, IBM LSF and Grid engine etc). For further information please refer the [Compute Environments](../../compute-envs/overview/) section.
+Tower uses the concept of **Compute Environments** to define the execution platform where a pipeline will be executed. Tower supports launching of pipelines into a growing number of cloud (Azure, AWS and GCP) and on-premise infrastructures (Slurm, IBM LSF and Grid engine etc). For further information please refer the [Compute Environments](/compute-envs/overview/) section.
 
 ## Credentials
 
-The **Credentials** section allows users to setup the access credentials for various platforms (Github, Gitlab and BitBucket) as well as various compute environments such as cloud, Slurm  or Kubernetes credentials etc. Please refer to the [Compute Environment](../../compute-envs/overview/) and [Git Integration](../../git/overview/) sections for instructions regarding your infrastructure. For further information please refer the [Credentials](../../credentials/overview/) section.
+The **Credentials** section allows users to setup the access credentials for various platforms (Github, Gitlab and BitBucket) as well as various compute environments such as cloud, Slurm  or Kubernetes credentials etc. Please refer to the [Compute Environment](/compute-envs/overview/) and [Git Integration](/git/overview/) sections for instructions regarding your infrastructure. For further information please refer the [Credentials](/credentials/overview/) section.

--- a/docs/git/overview.md
+++ b/docs/git/overview.md
@@ -11,5 +11,5 @@ By managing complex data pipelines as Git projects, all assets can be precisely 
 
 The following sections detail how to connect to public and private Git-hosting platforms to Tower:
 
-  * [Public Git repositories](../public_repositories/)
-  * [Private Git repositories](../private_repositories/)
+  * [Public Git repositories](/git/public_repositories/)
+  * [Private Git repositories](/git/private_repositories/)

--- a/docs/launch/launch.md
+++ b/docs/launch/launch.md
@@ -14,10 +14,10 @@ To launch a pipeline:
 
 The **Launch Form** view will appear.
 
-**2.** Select the drop down menu to choose a [**Compute Environment**](../../compute-envs/overview).  
+**2.** Select the drop down menu to choose a [**Compute Environment**](/compute-envs/overview).  
 
 !!! warning 
-    See the [**Compute Environment**](../../compute-envs/overview/) documentation to learn how to create an environment for your preferred executor environment.
+    See the [**Compute Environment**](/compute-envs/overview/) documentation to learn how to create an environment for your preferred executor environment.
 
 **3.** Enter the repository of the **Pipeline to launch**.  
 *For example https://github.com/nf-core/rnaseq.git*.
@@ -42,7 +42,7 @@ The **Launch Form** view will appear.
 **8.** Select *Launch* to begin the pipeline execution.
 
 !!! tip 
-    Nextflow pipelines are simply Git repositories and the location can be any public or private Git-hosting platform. See [**Git Integration**](../../git/overview/) in the Tower docs and [**Pipeline Sharing**](https://www.nextflow.io/docs/latest/sharing.html) in the Nextflow docs for more details.
+    Nextflow pipelines are simply Git repositories and the location can be any public or private Git-hosting platform. See [**Git Integration**](/git/overview/) in the Tower docs and [**Pipeline Sharing**](https://www.nextflow.io/docs/latest/sharing.html) in the Nextflow docs for more details.
 
 !!! warning 
     The credentials associated with the compute environment must be able to access the work directory.

--- a/docs/launch/launchpad.md
+++ b/docs/launch/launchpad.md
@@ -6,7 +6,7 @@ description: 'Curate and launch workflows'
 **Launchpad** makes it is easy for any workspace user to launch a pre-configured pipeline.
 
 
-![](../_images/overview_image.png)
+![](/_images/overview_image.png)
 
 
 A pipeline is a repository containing a Nextflow workflow, a compute environment and pipeline parameters.
@@ -17,7 +17,7 @@ Launchpad automatically detects the presence of a `nextflow_schema.json` in the 
 
 
 !!! tip
-    The parameter forms view will appear, if the workflow has a Nextflow schema file for the parameters. Please refer the [**Nextflow Schema guide**](../../nextflow-schema/overview) to learn more about the usa-cases and how to create them.
+    The parameter forms view will appear, if the workflow has a Nextflow schema file for the parameters. Please refer the [**Nextflow Schema guide**](/nextflow-schema/overview) to learn more about the usa-cases and how to create them.
 
 This makes it trivial for users without any expertise in Nextflow to enter their pipeline parameters and launch.
 
@@ -26,7 +26,7 @@ This makes it trivial for users without any expertise in Nextflow to enter their
 
 ## Adding a New Pipeline
 
-Adding a pipeline to the workspace launchpad is similar to the [Launch](../launch) except instead of launching the pipeline it gets added to the list of pipelines with the pre-saved values of fields such as the pipeline parameters and the revision number.
+Adding a pipeline to the workspace launchpad is similar to the [Launch](/launch/launch) except instead of launching the pipeline it gets added to the list of pipelines with the pre-saved values of fields such as the pipeline parameters and the revision number.
 
 !!! tip 
     To create your own customized Nextflow Schema for your pipleine, see the examples of from increasing number of `nf-core` workflows that have adopted this for example [eager](https://github.com/nf-core/eager/blob/2.3.3/nextflow_schema.json) and [rnaseq](https://github.com/nf-core/rnaseq/blob/3.0/nextflow_schema.json). 

--- a/docs/launch/launchpad.md
+++ b/docs/launch/launchpad.md
@@ -17,7 +17,7 @@ Launchpad automatically detects the presence of a `nextflow_schema.json` in the 
 
 
 !!! tip
-    The parameter forms view will appear, if the workflow has a Nextflow schema file for the parameters. Please refer the [**Nextflow Schema guide**](/nextflow-schema/overview) to learn more about the usa-cases and how to create them.
+    The parameter forms view will appear, if the workflow has a Nextflow schema file for the parameters. Please refer the [**Nextflow Schema guide**](/pipeline-schema/overview) to learn more about the use-cases and how to create them.
 
 This makes it trivial for users without any expertise in Nextflow to enter their pipeline parameters and launch.
 

--- a/docs/monitoring/execution.md
+++ b/docs/monitoring/execution.md
@@ -7,10 +7,10 @@ description: 'Monitoring a Nextflow pipeline executed through Tower.'
 Selecting a pipeline on the navigation bar will display the workflow details in the main monitoring panel. The main window contains:
 
 * [Execution section](#run-information) with command-line, parameters, configuration, and execution logs in real-time.
-* [Summary](../summary/) and [status section](../summary/).
-* List of pipeline [processes](../processes/).
-* Aggregated [stats](../aggregate_stats/) and [load](../aggregate_stats/#load-and-utilization).
-* Detailed list of [individual tasks](../tasks/#task-table) and [metrics](../tasks/#resource-metrics).
+* [Summary](/monitoring/summary/) and [status section](/monitoring/summary/).
+* List of pipeline [processes](/monitoring/processes/).
+* Aggregated [stats](/monitoring/aggregate_stats/) and [load](/monitoring/aggregate_stats/#load-and-utilization).
+* Detailed list of [individual tasks](/monitoring/tasks/#task-table) and [metrics](/monitoring/tasks/#resource-metrics).
 
 ## Run information
 

--- a/docs/monitoring/processes.md
+++ b/docs/monitoring/processes.md
@@ -10,5 +10,5 @@ In the example below, there are four tasks of the fastqc process.
 
 <img src="../_images/monitoring_fastqc_processes.png" width="50%"/>
 
-By selecting a process, the [**Tasks table**](../tasks/) is filtered below.
+By selecting a process, the [**Tasks table**](/monitoring/tasks/) is filtered below.
 

--- a/docs/orgs-and-teams/organizations.md
+++ b/docs/orgs-and-teams/organizations.md
@@ -51,11 +51,11 @@ An e-mail invitiation will be sent which needs to be accepted by the user, once 
 
 **Collaborators** are users who are invited to an organizations workspace, but are not members of that organization. As a result, their access is limited to only within that workspace.
 
-New collaborators to an organization's workspace can be added using the **Participants**. To further read the various available access levels for **Participants**, please refer the [participant roles](../../orgs-and-teams/workspace-management/#participant-roles) section.
+New collaborators to an organization's workspace can be added using the **Participants**. To further read the various available access levels for **Participants**, please refer the [participant roles](/orgs-and-teams/workspace-management/#participant-roles) section.
 
 
 !!! note
-    **Collaborator** can only be added from a workspace. For more information, please refer the [workspace management](../../orgs-and-teams/workspace-management#create-a-new-workspace) section. 
+    **Collaborator** can only be added from a workspace. For more information, please refer the [workspace management](/orgs-and-teams/workspace-management#create-a-new-workspace) section. 
 
 ## Teams
 

--- a/docs/orgs-and-teams/overview.md
+++ b/docs/orgs-and-teams/overview.md
@@ -8,13 +8,13 @@ description: 'Create and manage teams and resources for an organization.'
 
 Nextflow Tower simplifies the development and execution of workflows by providing a centralized interface to manage users and resources while providing ready-to-launch workflows for users.
 
-This is achieved through the context of Workspaces. To learn more about Workspaces, please refer the [Workspace](../../getting-started/workspace/) section. By default, each user has their own private workspace, while organizations can workspaces and manage users through role-based access as **members** and **collaborators**
+This is achieved through the context of Workspaces. To learn more about Workspaces, please refer the [Workspace](/getting-started/workspace/) section. By default, each user has their own private workspace, while organizations can workspaces and manage users through role-based access as **members** and **collaborators**
 
 ## Organization resources
 
 Tower allows creation of multiple organizations, each of which can contain multiple workspaces with shared users and resources. This allows any organization to customize and organize the usage of resources while maintaining an access control layer for users associated with a workspace.
 
-For further information, please refer the [Workspace Management](../workspace-management/) section.
+For further information, please refer the [Workspace Management](/orgs-and-teams/workspace-management/) section.
 
 ## Organization users
 
@@ -22,4 +22,4 @@ Any user can be added or removed from a particular organization or a workspace a
 
 The Teams feature provides a way for the organizations to group various users and participants together into teams, for example `workflow-developers` or `analysts`, and apply access control to all the users within this team as a whole.
 
-For further information, please refer the [User Management ](../organizations/) section.
+For further information, please refer the [User Management ](/orgs-and-teams/organizations/) section.

--- a/docs/orgs-and-teams/workspace-management.md
+++ b/docs/orgs-and-teams/workspace-management.md
@@ -22,7 +22,7 @@ To create a new workspace within an organization:
 !!!tip 
     It is possible to change the values of the optional fields either using the **Edit** option on the workspace listing for an organization or using the **Settings** tab within the workspace page, provided that you are the **Owner** of the workspace. 
 
-Apart from the **Participants** tab, the **organization workspace** is similar to the **user workspace** therefore, the concepts of [Runs](../../launch/launch/), [Pipeline Actions](../../pipeline-actions/pipeline-actions/), [Compute Environments](../../compute-envs/overview/) and [Credentials](../../credentials/overview/) are applicable.
+Apart from the **Participants** tab, the **organization workspace** is similar to the **user workspace** therefore, the concepts of [Runs](/launch/launch/), [Pipeline Actions](/pipeline-actions/pipeline-actions/), [Compute Environments](/compute-envs/overview/) and [Credentials](/credentials/overview/) are applicable.
 
 ### Add a new Participant
 


### PR DESCRIPTION
I was looking for information how to have Tower 'always turned on' via profiles/configs (rather than having to specify `-with-tower` every time), but could not find this on the Tower documentation. 

@drpatelh kindly pointed out this is possible by the `tower` scope of Nextflow configuration profiles, so this PR references this doucmentation in the Tower usage section.