### PR TITLE
Issue 132 k8s cluster prep

### DIFF
--- a/docs/_templates/eks-iam-policy.json
+++ b/docs/_templates/eks-iam-policy.json
@@ -1,0 +1,14 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Sid": "TowerEks0",
+        "Effect": "Allow",
+        "Action": [
+          "eks:ListClusters",
+          "eks:DescribeCluster"
+        ],
+        "Resource": "*"
+      }
+    ]
+  }

--- a/docs/_templates/tower-launcher.yml
+++ b/docs/_templates/tower-launcher.yml
@@ -1,0 +1,43 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tower-launcher-sa
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: tower-launcher-role
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "pods/status", "pods/log", "pods/exec", "jobs", "jobs/status", "jobs/log"]
+    verbs: ["get", "list", "watch", "create", "delete"]
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get", "list", "watch", "create", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: tower-launcher-rolebind
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: tower-launcher-role
+subjects:
+  - kind: ServiceAccount
+    name: tower-launcher-sa
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: tower-launcher-userbind
+subjects:
+  - kind: User
+    name: tower-launcher-user
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: Role
+  name: tower-launcher-role
+  apiGroup: rbac.authorization.k8s.io
+...

--- a/docs/_templates/tower-scratch-local.yml
+++ b/docs/_templates/tower-scratch-local.yml
@@ -1,0 +1,28 @@
+# Simple local volume scratch storage 
+# Only works for a single node cluster
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: tower-storage
+spec:
+  storageClassName: scratch
+  capacity:
+    storage: 10Gi
+  accessModes:
+    - ReadWriteMany
+  hostPath:
+    path: /tmp/tower
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: tower-scratch
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 10Gi
+  storageClassName: scratch
+...

--- a/docs/_templates/tower-scratch-nfs.yml
+++ b/docs/_templates/tower-scratch-nfs.yml
@@ -1,0 +1,92 @@
+# Simple container based  NFS server 
+# Only works for GKE, other K8s distrubution need the user of NSF IP address  
+# See https://github.com/kubernetes/minikube/issues/3417#issuecomment-670005434
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: nfs-server
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+  storageClassName: standard
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nfs-server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      role: nfs-server
+  template:
+    metadata:
+      labels:
+        role: nfs-server
+    spec:
+      containers:
+      - name: nfs-server
+        image: gcr.io/google_containers/volume-nfs:0.8
+        ports:
+          - name: nfs
+            containerPort: 2049
+          - name: mountd
+            containerPort: 20048
+          - name: rpcbind
+            containerPort: 111
+        securityContext:
+          privileged: true
+        volumeMounts:
+          - mountPath: /exports
+            name: vol-1
+      volumes:
+        - name: vol-1
+          persistentVolumeClaim:
+            claimName: nfs-server
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nfs-server
+spec:
+  ports:
+    - name: nfs
+      port: 2049
+    - name: mountd
+      port: 20048
+    - name: rpcbind
+      port: 111
+  selector:
+    role: nfs-server
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: nfs-storage
+spec:
+  capacity:
+    storage: 10Gi
+  accessModes:
+    - ReadWriteMany
+  nfs:
+    ## this only works with GKE, other cluster replace with nfs-server IP 
+    ## get the IP using the command `kubectl get service nfs-server`
+    server: nfs-server.tower-nf.svc.cluster.local
+    path: "/"
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: tower-scratch
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: ""
+  resources:
+    requests:
+      storage: 10Gi
+...

--- a/docs/compute-envs/eks.md
+++ b/docs/compute-envs/eks.md
@@ -11,7 +11,7 @@ Nextflow Tower offers native support for AWS EKS clusters and streamlines the de
 
 ## Requirements
 
-You need to have an EKS cluster up and running. Make sure you have followed the steps in the [Cluster preparation](/compute-envs/k8s/#cluster-preparation) guide to create the cluster resources required by Nextflow Tower. In addition to the generic Kubernetes instructions, you will need to make a few modifications specific to EKS.
+You need to have an EKS cluster up and running. Make sure you have followed the steps in the [cluster preparation](../k8s/#cluster-preparation) instructions to create the cluster resources required by Nextflow Tower. In addition to the generic Kubernetes instructions, you will need to make a few modifications specific to EKS.
 
 **Assign service account role to IAM user.** You will need to assign the service role with an AWS user that will be used by Tower to access the EKS cluster.
 
@@ -62,7 +62,7 @@ For more details, refer to the [AWS documentation](https://docs.aws.amazon.com/e
 **4.** Select your AWS credentials or create new ones. The credentials are needed to identify the user that will access the EKS cluster.
 
 !!! note 
-    Make sure the user has the IAM permissions required to describe and list EKS clusters as explained [here](/compute-envs/eks/#requirements).
+    Make sure the user has the IAM permissions required to describe and list EKS clusters as explained [here](#requirements).
 
 **5.** Specify the AWS *region* where the Kubernetes cluster is located e.g. `us-west-1`.
 
@@ -70,15 +70,15 @@ For more details, refer to the [AWS documentation](https://docs.aws.amazon.com/e
 
 **7.** Specify the Kubernetes **Namespace** that should be used to deploy the pipeline execution.
 
-If you followed the example from the [cluster preparation](/compute-envs/k8s/#cluster-preparation) instructions, this field should be `tower-nf`.
+If you followed the example from the [cluster preparation](../k8s/#cluster-preparation) instructions, this field should be `tower-nf`.
 
 **8.** Specify the Kubernetes **Head service account** that will be used to grant permissions to Tower to deploy the pod executions.
 
-If you followed the example from the [cluster preparation](/compute-envs/k8s/#cluster-preparation) instructions, this field should be `tower-launcher-sa`.
+If you followed the example from the [cluster preparation](../k8s/#cluster-preparation) instructions, this field should be `tower-launcher-sa`.
 
 **9.** The **Storage claim** field allows you to specify the storage Nextflow will use as a scratch file system for the pipeline execution.
 
-This should reference a Kubernetes persistent volume claim with `ReadWriteMany` access mode. See the [cluster preparation](/compute-envs/k8s/#cluster-preparation) instructions for details.
+This should reference a Kubernetes persistent volume claim with `ReadWriteMany` access mode. See the [cluster preparation](../k8s/#cluster-preparation) instructions for details.
 
 
 **10.** You can specify certain environment variables on the Head job or the Compute job using the **Environment variables** option.

--- a/docs/compute-envs/eks.md
+++ b/docs/compute-envs/eks.md
@@ -11,7 +11,42 @@ Nextflow Tower offers native support for AWS EKS clusters and streamlines the de
 
 ## Requirements
 
-You need to have an EKS cluster up and running. Make sure you have followed the steps in the [Cluster preparation](https://github.com/seqeralabs/nf-tower-k8s/blob/master/cluster-preparation.md) guide to create the cluster resources required by Nextflow Tower.
+You need to have an EKS cluster up and running. Make sure you have followed the steps in the [Cluster preparation](/compute-envs/k8s/#cluster-preparation) guide to create the cluster resources required by Nextflow Tower. In addition to the generic Kubernetes instructions, you will need to make a few modifications specific to EKS.
+
+**Assign service account role to IAM user.** You will need to assign the service role with an AWS user that will be used by Tower to access the EKS cluster.
+
+First, use the following command to modify the EKS auth configuration:
+```bash
+kubectl edit configmap -n kube-system aws-auth
+```
+
+Once the editor is open, add the following entry:
+```yaml
+  mapUsers: |
+    - userarn: <AWS USER ARN>
+      username: tower-launcher-user
+      groups:
+        - tower-launcher-role
+```
+
+Your user ARN can be retrieved from the [AWS IAM console](https://console.aws.amazon.com/iam) or from the AWS CLI:
+```bash
+aws sts get-caller-identity
+```
+
+!!! note "Note"
+    The same user needs to be used when specifying the AWS credentials in the configuration of the Tower compute environment for EKS.
+
+The AWS user should have the following IAM policy:
+
+<details>
+    <summary>Click to view eks-iam-policy.json</summary>
+    ```yaml
+    --8<-- "docs/_templates/eks-iam-policy.json"
+    ```
+</details>
+
+For more details, refer to the [AWS documentation](https://docs.aws.amazon.com/eks/latest/userguide/add-user-role.html).
 
 
 ## Compute environment setup  

--- a/docs/compute-envs/eks.md
+++ b/docs/compute-envs/eks.md
@@ -61,8 +61,8 @@ For more details, refer to the [AWS documentation](https://docs.aws.amazon.com/e
 
 **4.** Select your AWS credentials or create new ones. The credentials are needed to identify the user that will access the EKS cluster.
 
-!!! tip 
-    Make sure the user has the IAM permissions required to describe and list EKS clusters as explained at [this link](https://github.com/seqeralabs/nf-tower-k8s/blob/master/cluster-preparation.md#4-amazon-eks-specific-setting).
+!!! note 
+    Make sure the user has the IAM permissions required to describe and list EKS clusters as explained [here](/compute-envs/eks/#requirements).
 
 **5.** Specify the AWS *region* where the Kubernetes cluster is located e.g. `us-west-1`.
 
@@ -70,15 +70,15 @@ For more details, refer to the [AWS documentation](https://docs.aws.amazon.com/e
 
 **7.** Specify the Kubernetes **Namespace** that should be used to deploy the pipeline execution.
 
-If you have followed the example in the [cluster preparation](https://github.com/seqeralabs/nf-tower-k8s/blob/master/cluster-preparation.md#2-service-account--role-creation) guide, this field should be `tower-nf`.
+If you followed the example from the [cluster preparation](/compute-envs/k8s/#cluster-preparation) instructions, this field should be `tower-nf`.
 
 **8.** Specify the Kubernetes **Head service account** that will be used to grant permissions to Tower to deploy the pod executions.
 
-If you have followed the [cluster preparation](https://github.com/seqeralabs/nf-tower-k8s/blob/master/cluster-preparation.md#2-service-account--role-creation) guide, this field should be `tower-launcher-sa`.
+If you followed the example from the [cluster preparation](/compute-envs/k8s/#cluster-preparation) instructions, this field should be `tower-launcher-sa`.
 
 **9.** The **Storage claim** field allows you to specify the storage Nextflow will use as a scratch file system for the pipeline execution.
 
-This should reference a Kubernetes persistence volume with `ReadWriteMany` capability. See the [cluster preparation](https://github.com/seqeralabs/nf-tower-k8s/blob/master/cluster-preparation.md#3-storage-configuration) guide for details.
+This should reference a Kubernetes persistent volume claim with `ReadWriteMany` access mode. See the [cluster preparation](/compute-envs/k8s/#cluster-preparation) instructions for details.
 
 
 **10.** You can specify certain environment variables on the Head job or the Compute job using the **Environment variables** option.

--- a/docs/compute-envs/gke.md
+++ b/docs/compute-envs/gke.md
@@ -12,7 +12,7 @@ Nextflow Tower offers native support for Google GKE clusters and streamlines the
 
 ## Requirements
 
-You need to have a GKE cluster up and running. Make sure you have followed the steps in the [Cluster preparation](https://github.com/seqeralabs/nf-tower-k8s) guide to create the cluster resources required by Nextflow Tower. In addition to the generic Kubernetes instructions, you will need to make a few modifications specific to GKE.
+You need to have a GKE cluster up and running. Make sure you have followed the steps in the [Cluster preparation](/compute-envs/k8s/#cluster-preparation) guide to create the cluster resources required by Nextflow Tower. In addition to the generic Kubernetes instructions, you will need to make a few modifications specific to GKE.
 
 **Assign service account role to IAM user.** You will need to grant the cluster access to the service account used to authenticate the Tower compute environment. This can be done by updating the *role binding* as shown below:
 
@@ -66,15 +66,15 @@ For more details, refer to the [Google documentation](https://cloud.google.com/k
 
 **7.** Specify the Kubernetes **Namespace** that should be used to deploy pipeline executions.
 
-If you have followed the example in the [cluster preparation](https://github.com/seqeralabs/nf-tower-k8s/blob/master/cluster-preparation.md#2-service-account--role-creation) guide, this field should be `tower-nf`.
+If you followed the example from the [cluster preparation](/compute-envs/k8s/#cluster-preparation) instructions, this field should be `tower-nf`.
 
 **8.** Specify the Kubernetes **Head service account** that will be used to grant permissions to Tower to deploy the pods executions and related.
 
-If you have followed the [cluster preparation](https://github.com/seqeralabs/nf-tower-k8s/blob/master/cluster-preparation.md#2-service-account--role-creation) guide, this field should be `tower-launcher-sa`.
+If you followed the example from the [cluster preparation](/compute-envs/k8s/#cluster-preparation) instructions, this field should be `tower-launcher-sa`.
 
 **9.** The **Storage claim** field allows you to specify the storage Nextflow should use as a scratch file system for the pipeline execution.
 
-This should reference a Kubernetes persistence volume with `ReadWriteMany` capability. Check the [cluster preparation](https://github.com/seqeralabs/nf-tower-k8s/blob/master/cluster-preparation.md#3-storage-configuration) guide for details.
+This should reference a Kubernetes persistent volume claim with `ReadWriteMany` access mode. See the [cluster preparation](/compute-envs/k8s/#cluster-preparation) instructions for details.
 
 
 **10.** You can specify certain environment variables on the Head job or the Compute job using the **Environment variables** option.

--- a/docs/compute-envs/gke.md
+++ b/docs/compute-envs/gke.md
@@ -12,9 +12,32 @@ Nextflow Tower offers native support for Google GKE clusters and streamlines the
 
 ## Requirements
 
-You need to have a GKE cluster up and running. 
+You need to have a GKE cluster up and running. Make sure you have followed the steps in the [Cluster preparation](https://github.com/seqeralabs/nf-tower-k8s) guide to create the cluster resources required by Nextflow Tower. In addition to the generic Kubernetes instructions, you will need to make a few modifications specific to GKE.
 
-Make sure you have followed the steps in the [Cluster preparation](https://github.com/seqeralabs/nf-tower-k8s) guide to create the cluster resources required by Nextflow Tower.
+**Assign service account role to IAM user.** You will need to grant the cluster access to the service account used to authenticate the Tower compute environment. This can be done by updating the *role binding* as shown below:
+
+```yaml
+cat << EOF | kubectl apply -f -
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: tower-launcher-userbind
+subjects:
+  - kind: User
+    name: <IAM SERVICE ACCOUNT>
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: Role
+  name: tower-launcher-role
+  apiGroup: rbac.authorization.k8s.io
+...
+EOF
+```
+
+In the above snippet, replace `<IAM SERVICE ACCOUNT>` with the corresponding service account, e.g. `test-account@test-project-123456.google.com.iam.gserviceaccount.com`.
+
+For more details, refer to the [Google documentation](https://cloud.google.com/kubernetes-engine/docs/how-to/role-based-access-control).
 
 
 ## Compute environment setup

--- a/docs/compute-envs/gke.md
+++ b/docs/compute-envs/gke.md
@@ -12,7 +12,7 @@ Nextflow Tower offers native support for Google GKE clusters and streamlines the
 
 ## Requirements
 
-You need to have a GKE cluster up and running. Make sure you have followed the steps in the [Cluster preparation](/compute-envs/k8s/#cluster-preparation) guide to create the cluster resources required by Nextflow Tower. In addition to the generic Kubernetes instructions, you will need to make a few modifications specific to GKE.
+You need to have a GKE cluster up and running. Make sure you have followed the steps in the [cluster preparation](../k8s/#cluster-preparation) instructions to create the cluster resources required by Nextflow Tower. In addition to the generic Kubernetes instructions, you will need to make a few modifications specific to GKE.
 
 **Assign service account role to IAM user.** You will need to grant the cluster access to the service account used to authenticate the Tower compute environment. This can be done by updating the *role binding* as shown below:
 
@@ -66,15 +66,15 @@ For more details, refer to the [Google documentation](https://cloud.google.com/k
 
 **7.** Specify the Kubernetes **Namespace** that should be used to deploy pipeline executions.
 
-If you followed the example from the [cluster preparation](/compute-envs/k8s/#cluster-preparation) instructions, this field should be `tower-nf`.
+If you followed the example from the [cluster preparation](../k8s/#cluster-preparation) instructions, this field should be `tower-nf`.
 
 **8.** Specify the Kubernetes **Head service account** that will be used to grant permissions to Tower to deploy the pods executions and related.
 
-If you followed the example from the [cluster preparation](/compute-envs/k8s/#cluster-preparation) instructions, this field should be `tower-launcher-sa`.
+If you followed the example from the [cluster preparation](../k8s/#cluster-preparation) instructions, this field should be `tower-launcher-sa`.
 
 **9.** The **Storage claim** field allows you to specify the storage Nextflow should use as a scratch file system for the pipeline execution.
 
-This should reference a Kubernetes persistent volume claim with `ReadWriteMany` access mode. See the [cluster preparation](/compute-envs/k8s/#cluster-preparation) instructions for details.
+This should reference a Kubernetes persistent volume claim with `ReadWriteMany` access mode. See the [cluster preparation](../k8s/#cluster-preparation) instructions for details.
 
 
 **10.** You can specify certain environment variables on the Head job or the Compute job using the **Environment variables** option.

--- a/docs/compute-envs/k8s.md
+++ b/docs/compute-envs/k8s.md
@@ -9,7 +9,7 @@ description: 'Step-by-step instructions to set up a Nextflow Tower compute envir
 
 Tower streamlines the deployment of Nextflow pipelines into Kubernetes both in the cloud and in on-premises solutions.
 
-The following instructions are for a **generic Kubernetes** distribution. If you are using [Amazon EKS](/compute-envs/eks/) or [Google GKE](/compute-envs/gke/), see the corresponding documentation pages.
+The following instructions are for a **generic Kubernetes** distribution. If you are using [Amazon EKS](../eks/) or [Google GKE](../gke/), see the corresponding documentation pages.
 
 
 ## Cluster preparation
@@ -85,7 +85,7 @@ Example PVC backed by NFS server: [tower-scratch-nfs.yml](../_templates/tower-sc
     kubectl describe secret $SECRET | grep -E '^token' | cut -f2 -d':' | tr -d '\t'
     ```
 
-    Replace `<SERVICE-ACCOUNT-NAME>` with the name of the service account created in the [cluster preparation](/compute-envs/k8s/#cluster-preparation) instructions. If you followed the example in those instructions, it should be `tower-launcher-sa`.
+    Replace `<SERVICE-ACCOUNT-NAME>` with the name of the service account created in the [cluster preparation](#cluster-preparation) instructions. If you followed the example in those instructions, it should be `tower-launcher-sa`.
 
 
 **7.** Enter Kubernetes **Master server** URL
@@ -100,15 +100,15 @@ Example PVC backed by NFS server: [tower-scratch-nfs.yml](../_templates/tower-sc
 
 **9.** Specify Kubernetes **Namespace** that should be used to deployment the pipeline execution.
 
-If you followed the example from the [cluster preparation](/compute-envs/k8s/#cluster-preparation) instructions, this field should be `tower-nf`.
+If you followed the example from the [cluster preparation](#cluster-preparation) instructions, this field should be `tower-nf`.
 
 **10.** Specify the Kubernetes **Head service account** that will be used to grant permissions to Tower to deploy the pods executions and related.
 
-If you followed the example from the [cluster preparation](/compute-envs/k8s/#cluster-preparation) instructions, this field should be `tower-launcher-sa`.
+If you followed the example from the [cluster preparation](#cluster-preparation) instructions, this field should be `tower-launcher-sa`.
 
 **11.** The **Storage claim** field allows you to specify the storage that Nextflow should use as a scratch file system for the pipeline execution.
 
-This should reference a Kubernetes persistent volume claim with `ReadWriteMany` access mode. See the [cluster preparation](/compute-envs/k8s/#cluster-preparation) instructions for details.
+This should reference a Kubernetes persistent volume claim with `ReadWriteMany` access mode. See the [cluster preparation](#cluster-preparation) instructions for details.
 
 **12.** You can specify certain environment variables on the Head job or the Compute job using the **Environment variables** option.
 

--- a/docs/compute-envs/k8s.md
+++ b/docs/compute-envs/k8s.md
@@ -85,8 +85,7 @@ Example PVC backed by NFS server: [tower-scratch-nfs.yml](../_templates/tower-sc
     kubectl describe secret $SECRET | grep -E '^token' | cut -f2 -d':' | tr -d '\t'
     ```
 
-    Replace `<SERVICE-ACCOUNT-NAME>` with the name of the service account create in the [Cluster preparation](https://github.com/seqeralabs/nf-tower-k8s/blob/master/cluster-preparation.md#2-service-account--role-creation) step.
-    If you followed the example in the guide, it should be `tower-launcher-sa`.
+    Replace `<SERVICE-ACCOUNT-NAME>` with the name of the service account created in the [cluster preparation](/compute-envs/k8s/#cluster-preparation) instructions. If you followed the example in those instructions, it should be `tower-launcher-sa`.
 
 
 **7.** Enter Kubernetes **Master server** URL
@@ -101,18 +100,15 @@ Example PVC backed by NFS server: [tower-scratch-nfs.yml](../_templates/tower-sc
 
 **9.** Specify Kubernetes **Namespace** that should be used to deployment the pipeline execution.
 
-If you have followed the example in the [cluster preparation](https://github.com/seqeralabs/nf-tower-k8s/blob/master/cluster-preparation.md#2-service-account--role-creation) guide this field should be `tower-nf`.
+If you followed the example from the [cluster preparation](/compute-envs/k8s/#cluster-preparation) instructions, this field should be `tower-nf`.
 
 **10.** Specify the Kubernetes **Head service account** that will be used to grant permissions to Tower to deploy the pods executions and related.
 
-If you have followed the [cluster preparation](https://github.com/seqeralabs/nf-tower-k8s/blob/master/cluster-preparation.md#2-service-account--role-creation) guide this field should be `tower-launcher-sa`.
+If you followed the example from the [cluster preparation](/compute-envs/k8s/#cluster-preparation) instructions, this field should be `tower-launcher-sa`.
 
 **11.** The **Storage claim** field allows you to specify the storage that Nextflow should use as a scratch file system for the pipeline execution.
 
-This should reference a Kubernetes persistence volume with `ReadWriteMany` capability.
-
-Check the [cluster preparation](https://github.com/seqeralabs/nf-tower-k8s/blob/master/cluster-preparation.md#3-storage-configuration) guide for details.
-
+This should reference a Kubernetes persistent volume claim with `ReadWriteMany` access mode. See the [cluster preparation](/compute-envs/k8s/#cluster-preparation) instructions for details.
 
 **12.** You can specify certain environment variables on the Head job or the Compute job using the **Environment variables** option.
 

--- a/docs/compute-envs/k8s.md
+++ b/docs/compute-envs/k8s.md
@@ -47,7 +47,7 @@ kubectl apply -f tower-launcher.yaml
 
 This creates a service account called `tower-launcher-sa`. Use this service account name when setting up the compute environment for this Kubernetes cluster in Tower.
 
-**3. Configure persistent storage.** Tower requires a `ReadWriteMany` persistent volume claim (PVC) that is mounted by all nodes where workflow pods will be dispatched.
+**4. Configure persistent storage.** Tower requires a `ReadWriteMany` persistent volume claim (PVC) that is mounted by all nodes where workflow pods will be dispatched.
 
 You can use any storage solution that supports the `ReadWriteMany` access mode (see [this page](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes)). The setup of this storage is beyond the scope of these instructions, because the right solution for you will depend on what is available for your infrastructure or cloud vendor (NFS, GlusterFS, CephFS, Amazon FSx, etc). Ask your cluster administrator for more information.
 

--- a/docs/compute-envs/k8s.md
+++ b/docs/compute-envs/k8s.md
@@ -9,15 +9,51 @@ description: 'Step-by-step instructions to set up a Nextflow Tower compute envir
 
 Tower streamlines the deployment of Nextflow pipelines into Kubernetes both in the cloud and in on-premises solutions.
 
+The following instructions are for a **generic Kubernetes** distribution. If you are using [Amazon EKS](/compute-envs/eks/) or [Google GKE](/compute-envs/gke/), see the corresponding documentation pages.
 
-## Requirements
 
-You need to have Kubernetes cluster up and running. 
-Make sure you have followed the steps in the [Cluster preparation](https://github.com/seqeralabs/nf-tower-k8s) guide to create the cluster resources required by Nextflow Tower.
+## Cluster preparation
 
-The following instructions are for a **generic Kubernetes** distribution. 
+This section describes the steps required to prepare your Kubernetes cluster for the deployment of Nextflow pipelines using Tower. It is assumed the cluster itself has already been created and you have administrative privileges.
 
-If you are using [Amazon EKS](/compute-envs/eks/) or [Google GKE](/compute-envs/gke/), see the corresponding documentation pages.
+**1. Verify connection.** Make sure you are able to connect to your Kubernetes cluster:
+```bash
+kubectl cluster-info
+```
+
+**2. Create namespace.** While not mandatory, it is generally recommended to create a separate namespace for your Tower deployment. You can name it whatever you like, but we will name it `tower-nf` in these instructions:
+```bash
+kubectl create ns tower-nf
+```
+
+Switch to the new namespace:
+```bash
+kubectl config set-context --current --namespace=tower-nf
+```
+
+**3. Create service account and role.** The service account and corresponding rolebinding is used by Tower to launch Nextflow pipelines and by Nextflow to submit pipeline tasks. Download [tower-launcher.yml](../_templates/tower-launcher.yml) :fontawesome-solid-file-download: into your environment:
+
+<details>
+    <summary>Click to view tower-launcher.yml</summary>
+    ```yaml
+    --8<-- "docs/_templates/tower-launcher.yml"
+    ```
+</details>
+
+Then create the resources in your namespace:
+```bash
+kubectl apply -f tower-launcher.yaml
+```
+
+This creates a service account called `tower-launcher-sa`. Use this service account name when setting up the compute environment for this Kubernetes cluster in Tower.
+
+**3. Configure persistent storage.** Tower requires a `ReadWriteMany` persistent volume claim (PVC) that is mounted by all nodes where workflow pods will be dispatched.
+
+You can use any storage solution that supports the `ReadWriteMany` access mode (see [this page](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes)). The setup of this storage is beyond the scope of these instructions, because the right solution for you will depend on what is available for your infrastructure or cloud vendor (NFS, GlusterFS, CephFS, Amazon FSx, etc). Ask your cluster administrator for more information.
+
+Example PVC backed by local storage: [tower-scratch-local.yml](../_templates/tower-scratch-local.yml) :fontawesome-solid-file-download:
+
+Example PVC backed by NFS server: [tower-scratch-nfs.yml](../_templates/tower-scratch-nfs.yml) :fontawesome-solid-file-download:
 
 
 ## Compute environment setup  


### PR DESCRIPTION
Resolves #132 

The Kubernetes page now includes the cluster preparation instructions from the nf-tower-k8s repo. The EKS and GKE pages now link back to the cluster prep section of the k8s page, and they include the platform specific steps from the nf-tower-k8s instructions. Namely, on each cloud platform you have to link the k8s service account to an IAM user.

The config yml files are embedded like we do in the deployment docs, so users can download the files easily to their environment.