### PR TITLE
Add version callouts, remove separate versions

### DIFF
--- a/docs/datasets/overview.md
+++ b/docs/datasets/overview.md
@@ -8,11 +8,13 @@ description: 'Managing and using datasets in Nextflow Tower.'
 
 The **Datasets** functionality in Nextflow Tower allows the users to store CSV and TSV formatted files within a workspace and use those as an input one or more pipelines.
 
-
 ![](_images/datasets_listing.png)
 
+!!! note "Tower Enterprise"
+    This feature is also available in Tower Enterprise 21.10.x or later.
+
 !!! note
-    This feature is available only in the [organization workspaces.](../orgs-and-teams/workspace-management.md).
+    This feature is available only in [organization workspaces](../orgs-and-teams/workspace-management.md).
 
 
 

--- a/docs/orgs-and-teams/shared-workspaces.md
+++ b/docs/orgs-and-teams/shared-workspaces.md
@@ -6,6 +6,9 @@ description: 'Create and manage shared workspaces and resources in an organizati
 
 # Overview
 
+!!! note "Tower Enterprise"
+    This feature is also available in Tower Enterprise 21.12.x or later.
+
 We introduced the concept of shared workspaces as a solution to synchronization and resource sharing within an organization in Tower.
 
 With a shared workspace, it is now possible to create and set up pipelines in a single place (i.e. the shared workspace) which will become accessible to all members of an organization to be used.

--- a/docs/reports/overview.md
+++ b/docs/reports/overview.md
@@ -4,6 +4,9 @@ headline: 'Reports'
 description: 'Overview of the Tower pipeline Reports feature.'
 ---
 
+!!! note "Tower Enterprise"
+    This feature is also available in Tower Enterprise 22.1.x or later.
+
 ## Overview
 
 Most Nextflow pipelines will generate reports or output files which are useful to inspect at the end of the pipeline execution. Reports may be in various formats (e.g. HTML, PDF, TXT) and would typically contain quality control (QC) metrics that would be important to assess the integrity of the results. Tower has a Reports feature that allows you to directly visualise supported file types or to download them directly via the user interface (see [Limitations](#limitations)). This saves users the time and effort from having to retrieve and visualise output files from their local storage.

--- a/docs/secrets/overview.md
+++ b/docs/secrets/overview.md
@@ -8,8 +8,12 @@ description: 'Step-by-step instructions to set-up Secrets in Tower.'
 
 Tower uses the concept of **Secrets** to store the keys and tokens used by workflow tasks to interact with external systems e.g. a password to connect to an external database or an API token. Tower relies on third-party secret manager services in order to maintain security between the workflow execution context and the secret container. This means that no secure data is transmitted from Tower to the Compute Environment. 
 
-!!! note 
-    Currently only AWS Batch or HPC batch schedulers are supported. Please read more about the AWS Secret Manager [here](https://docs.aws.amazon.com/secretsmanager/index.html)
+!!! note "Tower Enterprise"
+    This feature is also available in Tower Enterprise 22.1.x or later.
+
+!!! note
+    Pipeline Secrets are currently only supported on AWS Batch and HPC schedulers.
+
 
 ## Pipeline Secrets
 
@@ -24,6 +28,7 @@ All of the available Secrets will be listed here and users with the appropriate 
 The form for creating or updating a Secret is very similar to the one used for Credentials.
 
 ![](_images/secrets_creation_form.png)
+
 
 ## Pipeline Secrets for users
 
@@ -42,9 +47,10 @@ When a new workflow is launched, all Secrets are sent to the corresponding secre
 
 Secrets will be automatically deleted from the secret manager when the Pipeline completes (successful or unsuccessful).
 
+
 ## AWS Secrets Manager Integration
 
-If you are planning to use the Pipeline Secrets feature provided by Tower with the AWS Secrets Manager, the following IAM permissions should be provided:
+If you are planning to use the Pipeline Secrets feature provided by Tower with the [AWS Secrets Manager](https://docs.aws.amazon.com/secretsmanager/index.html), the following IAM permissions should be provided:
  
 1. Create the AWS Batch [IAM Execution role](https://docs.aws.amazon.com/batch/latest/userguide/execution-IAM-role.html#create-execution-role) as specified in the AWS documentation.
 


### PR DESCRIPTION
This PR adds version callouts for Tower Enterprise, in particular:
- Datasets: 21.10.x
- Reports: 22.1.x (also previewed in 21.12.x but didn't mention)
- Shared Workspaces: 21.12.x
- Secrets: 22.1.x (also previewed in 21.12.x but didn't mention)

I used the changelog and release notes from the install docs for reference. Here are some notable features that weren't added because they aren't documented yet:
- Custom run names (22.1.x)
- MOAB platform (22.1.x)
- Tower Agent (21.12.x)
- Container registry creds for Azure (21.10.x)

I think we should merge these changes, remove the separate versions (@abhi18av will have to do that), and keep following this pattern as we document new features, including the ones listed above.

Graham's functionality matrix also lists a few undocumented features. I think his matrix should be kept for tracking version requirements between Tower Cloud/Enterprise, Tower API, and Tower CLI, but version requirements for individual features should be placed directly into the documentation.