### PR TITLE
Modified previous entries and S3 unstaging entry

### DIFF
--- a/docs/faqs.md
+++ b/docs/faqs.md
@@ -207,7 +207,6 @@ k8s.securityContext = [
 ```
 
 
-
 ### Datasets
 
 **<p data-question>Q: Why are uploads of Datasets via direct calls to the Tower API failing?</p>**
@@ -500,6 +499,16 @@ Yes. Tower-invoked jobs can pull container images from private docker registries
     `cp /root/.docker/config.json /home/ec2-user/.docker/config.json && chmod 777 /home/ec2-user/.docker/config.json`
 - If using Azure Batch, please create a **Container Registry**-type credential in your Tower Workspace and associate it with the Azure Batch object also defined in the Workspace.
 - If using Kubernetes, please use an `imagePullSecret` as per [https://github.com/nextflow-io/nextflow/issues/2827](https://github.com/nextflow-io/nextflow/issues/2827).
+
+
+**<p data-question>Q: Why does my Nextflow log have a `Remote resource not found` error when trying to contact the workflow repository? </p>**
+
+This error can occur if the Nextflow head job fails to retrieve the necessary repository credentials from Nextflow Tower. 
+
+To determine if this is the case, please do the following: 
+
+1. Check your Nextflow log for an entry like `DEBUG nextflow.scm.RepositoryProvider - Request [credentials -:-]`.
+2. If the above is true, please check the protocol of the string that was assigned to your Tower instance's `TOWER_SERVER_URL` configuration value. It is possible this has been erroneously set to `http` rather than `https`.
 
 
 ### Secrets


### PR DESCRIPTION
Seeking @abhi18av & @markpanganiban review since I'm modifying content pushed in by a previous PR while I was away: https://github.com/seqeralabs/nf-tower-docs/pull/208

Changes:

- Added entry related to intermediate files being unstaged to S3 due to presence in a process output. [https://seqera.slack.com/archives/C03B8PGQUNL/p1659548322709679]

- Moved Execution Role entry to Secrets heading. 
This is not a Nextflow config issue, but rather one related to IAM Roles tied to the AWS Batch CE. [https://github.com/seqeralabs/support-backlog/issues/179]

- Re-Wrote "... unable to pull a private pipeline from Github" entry: 
Although the client received a `Remote resource not found` in their logs when calling GitHub, this was a result of the fact that they had misconfigured the `TOWER_SERVER_URL` protocol incorrectly (http instead of https). Entry was re-written to make it git-repo agnostic and provide additional guidance on what to look for in Nextflow logs. [https://github.com/seqeralabs/support-backlog/issues/205]

- Deleted "DockerTimeoutError" entry:
There are many more reasons why clients can receive this error, and not just on spot-instances. This should be added as a more fulsome entry once we can better enumerate all the reasons for this error to occur.

- Deleted "Pipeline to launch field" entry:
  This issue is more related to container behaviour in a locked down environment. Could not replicate aspects of asserted behaviour in conversation. Pulling entry and noting as candidate for more fulsome rewrite.
