### PR TITLE
Tower backlog issue 788: Update Compute Environment pages with GPU enablement info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 node_modules/
 .env
 yarn.lock
+oas-strapi-test/
 
 # Don't add personal VS Code settings
 .vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@
 node_modules/
 .env
 yarn.lock
-oas-strapi-test/
 
 # Don't add personal VS Code settings
 .vscode/

--- a/docs/compute-envs/aws-batch.md
+++ b/docs/compute-envs/aws-batch.md
@@ -81,8 +81,8 @@ S3 stands for "Simple Storage Service" and is a type of **object storage**. To a
     !!! warning "S3 Storage Costs"
         S3 is used by Nextflow for the storage of intermediate files. For production pipelines, this can amount to a large quantity of data. To reduce costs, when configuring a bucket, users should consider using a retention policy, such as automatically deleting intermediate files after 30 days. For more information on this process, see [here](https://aws.amazon.com/premiumsupport/knowledge-center/s3-empty-bucket-lifecycle-rule/).
 
-!!! note "Congratulations!"
-    You have completed the AWS environment setup for Tower.
+!!! note "AWS setup complete"
+    You have now completed the AWS environment setup for Tower.
 
 
 ### Compute Environment
@@ -174,7 +174,7 @@ Jump to the documentation for [Launching Pipelines](../launch/launchpad.md).
 - You can use your own **AMI**.
 
     !!! warning "Requirements for custom AMI"
-        To use a custom AMI, make sure the AMI is based on an Amazon Linux-2 ECS optimized image that meets the Batch requirements. To learn more about approved versions of the Amazon ECS optimized AMI, visit [this link](https://docs.aws.amazon.com/batch/latest/userguide/compute_resource_AMIs.html#batch-ami-spec)
+        To use a custom AMI, make sure the AMI is based on an Amazon Linux-2 ECS optimized image that meets the Batch requirements. When a custom AMI is specified here, the AWS-recommended AMI selection from step 14 (Enable GPUs) is ignored. To learn more about approved versions of the Amazon ECS optimized AMI, see [this AWS guide](https://docs.aws.amazon.com/batch/latest/userguide/compute_resource_AMIs.html#batch-ami-spec)
 
 - If you need to debug the EC2 instance provisioned by AWS Batch, specify a **Key pair** to login to the instance via SSH.
 

--- a/docs/compute-envs/aws-batch.md
+++ b/docs/compute-envs/aws-batch.md
@@ -81,8 +81,8 @@ S3 stands for "Simple Storage Service" and is a type of **object storage**. To a
     !!! warning "S3 Storage Costs"
         S3 is used by Nextflow for the storage of intermediate files. For production pipelines, this can amount to a large quantity of data. To reduce costs, when configuring a bucket, users should consider using a retention policy, such as automatically deleting intermediate files after 30 days. For more information on this process, see [here](https://aws.amazon.com/premiumsupport/knowledge-center/s3-empty-bucket-lifecycle-rule/).
 
-!!! note "AWS setup complete"
-    You have now completed the AWS environment setup for Tower.
+!!! note "Congratulations!"
+    You have completed the AWS environment setup for Tower.
 
 
 ### Compute Environment
@@ -138,11 +138,11 @@ Once the AWS resources are set up, we can add a new **AWS Batch** environment in
     !!! tip
         You are not required to modify your pipeline or files to take advantage of this feature. Nextflow is able to recognise these buckets automatically and will replace any reference to files prefixed with `s3://` with the corresponding Fusion mount paths.
 
-14. Select **Enable GPUs** to allow the deployment of GPU-enabled EC2 instances if required. Note that:
+14. Select **Enable GPU** to allow the deployment of GPU-enabled EC2 instances if required.
 
-    - The **Enable GPUs** setting causes Forge to specify an [AWS-recommended GPU-optimized ECS AMI](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html). This does not deploy any GPU instances automatically. You still need to specify these instance types in the **Advanced options > Instance types** field.
-    - Any AMI you specify in the **Advanced options > AMI Id** field supercedes the AWS-recommended selection above.
+    - This setting only causes Forge to use an [AWS-recommended GPU-optimized AMI](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html). You still need to specify one or more GPU-based **Instance types** in the advanced options.
 
+    - This setting can be overridden by **AMI Id** in the advanced options.
 
 15. Enter any additional **Allowed S3 buckets** that your workflows require to read input data or write output data. The **Pipeline work directory** bucket above is added by default to the list of **Allowed S3 buckets**.
 
@@ -171,10 +171,13 @@ Jump to the documentation for [Launching Pipelines](../launch/launchpad.md).
 
 - You can configure your custom networking setup using the **VPC**, **Subnets** and **Security groups** fields.
 
-- You can use your own **AMI**.
+- You can specify a custom **AMI Id**.
 
     !!! warning "Requirements for custom AMI"
-        To use a custom AMI, make sure the AMI is based on an Amazon Linux-2 ECS optimized image that meets the Batch requirements. When a custom AMI is specified here, the AWS-recommended AMI selection from step 14 (Enable GPUs) is ignored. To learn more about approved versions of the Amazon ECS optimized AMI, see [this AWS guide](https://docs.aws.amazon.com/batch/latest/userguide/compute_resource_AMIs.html#batch-ami-spec)
+        To use a custom AMI, make sure the AMI is based on an Amazon Linux-2 ECS optimized image that meets the Batch requirements. To learn more about approved versions of the Amazon ECS optimized AMI, see [this AWS guide](https://docs.aws.amazon.com/batch/latest/userguide/compute_resource_AMIs.html#batch-ami-spec)
+
+    !!! warning "GPU-enabled AMI"
+        If a custom AMI is specified and the **Enable GPU** option is also selected, the custom AMI will be used instead of the AWS-recommended GPU-optimized AMI.
 
 - If you need to debug the EC2 instance provisioned by AWS Batch, specify a **Key pair** to login to the instance via SSH.
 

--- a/docs/compute-envs/aws-batch.md
+++ b/docs/compute-envs/aws-batch.md
@@ -138,10 +138,10 @@ Once the AWS resources are set up, we can add a new **AWS Batch** environment in
     !!! tip
         You are not required to modify your pipeline or files to take advantage of this feature. Nextflow is able to recognise these buckets automatically and will replace any reference to files prefixed with `s3://` with the corresponding Fusion mount paths.
 
-14. Select **Enable GPU** to allow the deployment of GPU-enabled EC2 instances if required.
+14. Select **Enable GPUs** if you intend to run GPU-dependent workflows in the compute environment. Note that:
 
-    - This setting only causes Forge to use an [AWS-recommended GPU-optimized AMI](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html). You still need to specify one or more GPU-based **Instance types** in the advanced options.
-
+    - The **Enable GPUs** setting does not cause GPU instances to deploy in your compute environment. You must still specify GPU-enabled instance types in the **Advanced options > Instance types** field. 
+    - The **Enable GPUs** setting causes Forge to specify the most current [AWS-recommended GPU-optimized ECS AMI](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html) as the EC2 fleet AMI when creating the compute environment. 
     - This setting can be overridden by **AMI Id** in the advanced options.
 
 15. Enter any additional **Allowed S3 buckets** that your workflows require to read input data or write output data. The **Pipeline work directory** bucket above is added by default to the list of **Allowed S3 buckets**.

--- a/docs/compute-envs/aws-batch.md
+++ b/docs/compute-envs/aws-batch.md
@@ -138,7 +138,11 @@ Once the AWS resources are set up, we can add a new **AWS Batch** environment in
     !!! tip
         You are not required to modify your pipeline or files to take advantage of this feature. Nextflow is able to recognise these buckets automatically and will replace any reference to files prefixed with `s3://` with the corresponding Fusion mount paths.
 
-14. Select **Enable GPUs** to allow the deployment of GPU-enabled EC2 instances if required.
+14. Select **Enable GPUs** to allow the deployment of GPU-enabled EC2 instances if required. Note that:
+
+    - The **Enable GPUs** setting causes Forge to specify an [AWS-recommended GPU-optimized ECS AMI](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html). This does not deploy any GPU instances automatically. You still need to specify these instance types in the **Advanced options > Instance types** field.
+    - Any AMI you specify in the **Advanced options > AMI Id** field supercedes the AWS-recommended selection above.
+
 
 15. Enter any additional **Allowed S3 buckets** that your workflows require to read input data or write output data. The **Pipeline work directory** bucket above is added by default to the list of **Allowed S3 buckets**.
 

--- a/docs/compute-envs/azure-batch.md
+++ b/docs/compute-envs/azure-batch.md
@@ -84,7 +84,7 @@ When you open [this link](https://portal.azure.com/#blade/HubsExtension/BrowseRe
 
 4. Select **Create** to create the Azure Batch account.
 
-!!! note "Congratulations!"
+!!! note "Azure setup complete"
     You have completed the Azure environment setup for Tower.
 
 
@@ -127,7 +127,10 @@ Once the Azure resources are set up, we can add a new **Azure Batch** environmen
 
     ![](_images/azure_tower_forge.png)
 
-10. Enter the default VM type depending on your quota limits. The default is `Standard_D4_v3`.
+10. Enter the default VM type depending on your quota limits. The default is `Standard_D4_v3`. 
+
+!!! note
+    To enable the use of GPUs in your compute environment, specify a GPU-optimized VMI (or a custom VMI which meets the GPU-optimized [requirements](https://docs.nvidia.com/ngc/ngc-deploy-public-cloud/ngc-azure/index.html#azure-vmi)) in the **VMs type** field.
 
 11. Enter the **VMs count**, which is the number of VMs you'd like to deploy.
 
@@ -181,7 +184,7 @@ To create a new compute environment for AWS Batch (without Forge):
 8. Enter the **Pipeline work directory** as the Azure blob container we created in the previous section, e.g. `az://towerrgstorage-container/work`.
 
     !!! warning
-        The blob container should be in the same **Region** from the previous step.
+        The blob container should be in the same **Region** you specified in step 7 above.
 
 9. Set the **Config mode** to **Manual**.
 

--- a/docs/compute-envs/azure-batch.md
+++ b/docs/compute-envs/azure-batch.md
@@ -126,9 +126,6 @@ Once the Azure resources are set up, we can add a new **Azure Batch** environmen
 
 10. Enter the default VM type depending on your quota limits. The default is `Standard_D4_v3`. 
 
-!!! note
-    To enable the use of GPUs in your compute environment, specify a GPU-optimized VMI (or a custom VMI which meets the GPU-optimized [requirements](https://docs.nvidia.com/ngc/ngc-deploy-public-cloud/ngc-azure/index.html#azure-vmi)) in the **VMs type** field.
-
 11. Enter the **VMs count**, which is the number of VMs you'd like to deploy.
 
 12. Enable **Autoscale** if you'd like to automatically scale up and down based on the number of tasks. The number of VMs will vary from **0** to **VMs count**.

--- a/docs/compute-envs/azure-batch.md
+++ b/docs/compute-envs/azure-batch.md
@@ -84,7 +84,7 @@ When you open [this link](https://portal.azure.com/#blade/HubsExtension/BrowseRe
 
 4. Select **Create** to create the Azure Batch account.
 
-!!! note "Azure setup complete"
+!!! note "Congratulations!"
     You have completed the Azure environment setup for Tower.
 
 

--- a/docs/compute-envs/overview.md
+++ b/docs/compute-envs/overview.md
@@ -42,10 +42,4 @@ If you have more than one compute environment, you can select which one will be 
 
 The process for provisioning GPU instances in your compute environments differs for each cloud provider:
 
-### AWS Batch
-When selecting AWS Batch from the **Platform** list, the New Compute Environment form includes an **Enable GPUs** toggle option. Note that setting this option means that Tower Forge will specify an [AWS-recommended GPU-optimized ECS AMI](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html). This does not deploy any GPU instances automatically. You still need to specify these instance types in the **Advanced options > Instance types** field.
-
-Any AMI you manually specify (using the **Advanced options > AMI ID** field) will overwrite the AWS-recommended selection above. 
-
-### Azure Batch
-From the New Compute Environment form, select **Batch Forge** under **Config Mode**. Then specify a GPU-optimized VMI (or a custom VMI which meets the GPU-optimized [requirements](https://docs.nvidia.com/ngc/ngc-deploy-public-cloud/ngc-azure/index.html#azure-vmi)) in the **VMs type** field. 
+See [AWS Batch](./aws-batch.md#compute-environment14)

--- a/docs/compute-envs/overview.md
+++ b/docs/compute-envs/overview.md
@@ -39,3 +39,15 @@ If you have more than one compute environment, you can select which one will be 
 
 !!! tip "Congratulations!" 
     You are now ready to launch pipelines with your primary compute environment.
+
+## GPU usage
+
+The process for provisioning GPU instances in your compute environments differs for each cloud provider:
+
+### AWS Batch
+When selecting AWS Batch from the **Platform** list, the New Compute Environment form includes an **Enable GPUs** toggle option. Note that setting this option means that Tower Forge will specify an [AWS-recommended GPU-optimized ECS AMI](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html). This does not deploy any GPU instances automatically. You still need to specify these instance types in the **Advanced options > Instance types** field.
+
+Any AMI you manually specify (using the **Advanced options > AMI ID** field) will overwrite the AWS-recommended selection above. 
+
+### Azure Batch
+From the New Compute Environment form, select **Batch Forge** under **Config Mode**. Then specify a GPU-optimized VMI (or a custom VMI which meets the GPU-optimized [requirements](https://docs.nvidia.com/ngc/ngc-deploy-public-cloud/ngc-azure/index.html#azure-vmi)) in the **VMs type** field. 

--- a/docs/compute-envs/overview.md
+++ b/docs/compute-envs/overview.md
@@ -40,6 +40,6 @@ If you have more than one compute environment, you can select which one will be 
 
 ## GPU usage
 
-The process for provisioning GPU instances in your compute environments differs for each cloud provider:
+The process for provisioning GPU instances in your compute environment differs for each cloud provider:
 
 See [AWS Batch](./aws-batch.md#compute-environment14)


### PR DESCRIPTION
This PR updates the following Compute Environments pages on help.tower.nf:

-Overview: Add GPU Usage section to main overview page with summary paragraphs on AWS and Azure
-AWS Batch - Add GPU Enabled toggle information and context to instructions, link to [AWS docs](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html)
-Azure Batch - Add information for specifying GPU-enabled VM types, link to [Nvidia docs](https://docs.nvidia.com/ngc/ngc-deploy-public-cloud/ngc-azure/index.html#azure-vmi)