### PR TITLE
Schema docs edit

### DIFF
--- a/docs/pipeline-schema/overview.md
+++ b/docs/pipeline-schema/overview.md
@@ -49,7 +49,7 @@ Once your pipeline schema file has been built with the `nf-core schema build`, t
 
 The tool also checks the status of your schema on the website and once complete, it saves your changes to the file locally. 
 
-Furthermore, you will get a **Build ID/Schema cache ID** as can be seen above, so if for any reason you already ran the `nf-core schema build` command and forgot to save your changes, you can resume editing your JSON schema file by using [our schema builder] (https://nf-co.re/pipeline_schema_builder). 
+Furthermore, you will get a **Build ID/Schema cache ID** as can be seen above, so if for any reason you already ran the `nf-core schema build` command and forgot to save your changes, you can resume editing your JSON schema file by using [our schema builder](https://nf-co.re/pipeline_schema_builder). 
 
 If the tool **does not** automatically take you to the nf-core website to customize your JSON schema file, please click on [the following link](https://nf-co.re/pipeline_schema_builder). 
 

--- a/docs/pipeline-schema/overview.md
+++ b/docs/pipeline-schema/overview.md
@@ -6,23 +6,16 @@ description: 'A brief introduction to Pipeline Schema.'
 
 ## Overview
 
-This page will give you a detailed description of what pipeline schema files are, why they are used and to give you an in-depth description of how to build and customize your own Pipeline JSON schema file. 
+This page will give you a detailed description of what pipeline schema files are, why they are used and to give you an in-depth description of how to build and customize your own Pipeline JSON schema file.
 
-![](_images/pipeline_schema_form.png)
-
-
-## What is a Pipeline schema? 
-
-In short, the main use of pipeline schema is to describe the structure and validation constraints of your workflow parameters. Schemas in general are used to validate parameters before use to prevent software/pipelines failing in unexpected ways at runtime. 
-
-You can create a UI for your pipeline parameters using the **pipeline schema**.
+![Tower Launch interface](_images/pipeline_schema_form.png)
 
 
-## Why do you need a schema file for your pipelines or software applications?
+## What is a Pipeline schema?
 
-Pipeline schema file is used to describe the different paraments used by the Nextflow workflow and the input parameters that the pipeline accepts.
+Pipeline schema files describe the structure and validation constraints of your workflow parameters. They are used to validate parameters before launch to prevent software/pipelines failing in unexpected ways at runtime.
 
-Nextflow Tower uses this file to automatically generate the pipeline inputs form and validate the user provided parameters in a user friendly way.
+Tower uses pipeline schema to build the launchpad parameters form.
 
 !!! tip
     You can populate the parameters in the pipeline, by uploading a YAML or a JSON file, in addition to filling it on the UI itself.
@@ -30,51 +23,24 @@ Nextflow Tower uses this file to automatically generate the pipeline inputs form
 
 ## How can I build my own Pipeline schema file for my Nextflow pipelines?
 
-The pipeline schema is based on [json-schema.org](https://json-schema.org/) syntax, 
-therefore it can be written with a simple text editior, even though can difficult for complex pipelines.
+The pipeline schema is based on [json-schema.org](https://json-schema.org/) syntax, with some additional conventions. It can quickly get very complex so do not recommend creating or editing this file manually.
 
-The [nf-core](https://nf-co.re/) project provides an handy tool that helps writing the schema 
-file by running the `nf-core schema build` command in the pipeline root directoty.
+Instead, we recommmend using tools from the [nf-core](https://nf-co.re/) project, which provides a toolset for developing Nextflow pipelines.
 
-It collects your pipeline parameters and gives you interactive prompts about any missing or unexpected parameters. If no existing schema is found, it will automatically create a JSON schema file for you.
+Running the `nf-core schema build` command in your pipeline root directory will collect your pipeline parameters and give you interactive prompts about any missing or unexpected parameters. If no existing schema file is found, it will automatically create one for you.
 
 For more information, please follow [this link](https://nf-co.re/tools/#build-a-pipeline-schema).
 
 
-## How can I individualize or edit the automatically created schema file?
+## How can I customise my schema file?
 
-Once your pipeline schema file has been built with the `nf-core schema build`, the tool can send the schema to the nf-core website so that you can use a [graphical interface](https://nf-co.re/pipeline_schema_builder) to organize and fill in the schema. 
+Once the skeleton pipeline schema file has been built with the `nf-core schema build`, the command line tool will prompt you to open a [graphical schema editor](https://nf-co.re/pipeline_schema_builder) on the nf-core website.
 
-![](./_images/pipeline_schema_overview.png)
+![nf-core schema builder interface](./_images/pipeline_schema_overview.png)
 
-The tool also checks the status of your schema on the website and once complete, it saves your changes to the file locally. 
-
-Furthermore, you will get a **Build ID/Schema cache ID** as can be seen above, so if for any reason you already ran the `nf-core schema build` command and forgot to save your changes, you can resume editing your JSON schema file by using [our schema builder](https://nf-co.re/pipeline_schema_builder). 
-
-If the tool **does not** automatically take you to the nf-core website to customize your JSON schema file, please click on [the following link](https://nf-co.re/pipeline_schema_builder). 
-
-1. Open the link above.
-
-2. Copy the schema code you have received into the box below **Paste your JSON Schema** in the **New Schema** section. 
-
-3. Select **Submit**. 
-
-    ![](./_images/paste_pipeline_schema.png)
-
-You will be automatically redirected to the JSON schema builder website, where you can then add parameters, groups and much more. Once you are done editing the schema file, select **Finished**. 
-
-![](./_images/paste_pipeline_sample.png)
+Leave the command-line tool running in the background - it checks the status of your schema on the website. When you click <kbd>Finished</kbd> on the website, it will automatically save your changes to the file locally.
 
 
-## Can I use the pipeline schema builder for pipelines outside of nf-core? 
+## Can I use the pipeline schema builder for pipelines outside of nf-core?
 
-Yes. The schema builder is a tool created by the nf-core community to make the creation and editing of Pipeline schema files easier for developers. Thus, it can be used to create any kind of pipeline. 
-
-
-## What changes can I make to my schema file with the pipeline schema builder?
-
-You can add parameters such as identifiers (e.g. `productId`), a product name (e.g. `productName`), a selling cost and tags. Additionally, you can define the properties of the identifiers and add groups. 
-
-For a more in depth guide on schema files, please follow [this](https://json-schema.org/learn/getting-started-step-by-step.html) and [this](https://json-schema.org/specification.html) link.
-
-If you click on the **Help** button in the pipeline schema builder website, you will also be able to get an in-depth explanation of the possible parameters and tips on how to create a schema that fits your needs. 
+Yes. The schema builder is created by the nf-core community but should work for any Nextflow pipeline.

--- a/docs/pipeline-schema/overview.md
+++ b/docs/pipeline-schema/overview.md
@@ -6,7 +6,7 @@ description: 'A brief introduction to Pipeline Schema.'
 
 ## Overview
 
-This page will give you a detailed description of what pipeline schema files are, why they are used and to give you an in-depth description of how to build and customize your own Pipeline JSON schema file.
+This page will give you a detailed description of what pipeline schema files are, why they are used, and show you how to build and customize your own Pipeline JSON schema file.
 
 ![Tower Launch interface](_images/pipeline_schema_form.png)
 

--- a/docs/pipeline-schema/overview.md
+++ b/docs/pipeline-schema/overview.md
@@ -23,11 +23,11 @@ Tower uses pipeline schema to build the launchpad parameters form.
 
 ## How can I build my own Pipeline schema file for my Nextflow pipelines?
 
-The pipeline schema is based on [json-schema.org](https://json-schema.org/) syntax, with some additional conventions. It can quickly get very complex so do not recommend creating or editing this file manually.
+The pipeline schema is based on [json-schema.org](https://json-schema.org/) syntax, with some additional conventions. This can get complex, so we do not recommend creating or editing this file manually.
 
 Instead, we recommmend using tools from the [nf-core](https://nf-co.re/) project, which provides a toolset for developing Nextflow pipelines.
 
-Running the `nf-core schema build` command in your pipeline root directory will collect your pipeline parameters and give you interactive prompts about any missing or unexpected parameters. If no existing schema file is found, it will automatically create one for you.
+Running the `nf-core schema build` command in your pipeline root directory collects your pipeline parameters and gives you interactive prompts about missing or unexpected parameters. If no existing schema file is found, it will create one for you.
 
 For more information, please follow [this link](https://nf-co.re/tools/#build-a-pipeline-schema).
 
@@ -43,4 +43,4 @@ Leave the command-line tool running in the background - it checks the status of 
 
 ## Can I use the pipeline schema builder for pipelines outside of nf-core?
 
-Yes. The schema builder is created by the nf-core community but should work for any Nextflow pipeline.
+Yes. The schema builder is created by the nf-core community, but should work for any Nextflow pipeline.

--- a/docs/pipeline-schema/overview.md
+++ b/docs/pipeline-schema/overview.md
@@ -51,7 +51,7 @@ The tool also checks the status of your schema on the website and once complete,
 
 Furthermore, you will get a **Build ID/Schema cache ID** as can be seen above, so if for any reason you already ran the `nf-core schema build` command and forgot to save your changes, you can resume editing your JSON schema file by using [our schema builder] (https://nf-co.re/pipeline_schema_builder). 
 
-If the tool **does not** automatically take you to the nf-core website to customize your JSON schema file, please click on [the following link] (https://nf-co.re/pipeline_schema_builder). 
+If the tool **does not** automatically take you to the nf-core website to customize your JSON schema file, please click on [the following link](https://nf-co.re/pipeline_schema_builder). 
 
 1. Open the link above.
 


### PR DESCRIPTION
I found the schema docs very confusing to read, so after [fixing a couple of markdown links](https://github.com/seqeralabs/nf-tower-docs/pull/275) I couldn't resist also working on the text a little.

Broadly speaking, I:

- Really try to avoid talking about JSON schema too much, as we do quite a lot of stuff outside of JSON schema spec and also don't support all of it, so it invites trouble to suggest that people should look into that
- Removed quite a lot of duplication and slightly confusing wording
- Removed all the stuff about manually copying and pasting schemas and IDs and stuff in the case that it fails. Failure should be very rare and I found it made the text a lot more confusing to read.

Did this quite quickly so happy to discuss changes / have this PR closed.