### PR TITLE
271 improve documentation for container credentials

### DIFF
--- a/docs/compute-envs/aws-batch.md
+++ b/docs/compute-envs/aws-batch.md
@@ -81,9 +81,6 @@ S3 stands for "Simple Storage Service" and is a type of **object storage**. To a
     !!! warning "S3 Storage Costs"
         S3 is used by Nextflow for the storage of intermediate files. For production pipelines, this can amount to a large quantity of data. To reduce costs, when configuring a bucket, users should consider using a retention policy, such as automatically deleting intermediate files after 30 days. For more information on this process, see [here](https://aws.amazon.com/premiumsupport/knowledge-center/s3-empty-bucket-lifecycle-rule/).
 
-!!! note "Congratulations!"
-    You have completed the AWS environment setup for Tower.
-
 
 ### Compute Environment
 
@@ -138,7 +135,11 @@ Once the AWS resources are set up, we can add a new **AWS Batch** environment in
     !!! tip
         You are not required to modify your pipeline or files to take advantage of this feature. Nextflow is able to recognise these buckets automatically and will replace any reference to files prefixed with `s3://` with the corresponding Fusion mount paths.
 
-14. Select **Enable GPUs** to allow the deployment of GPU-enabled EC2 instances if required.
+14. Select **Enable GPUs** if you intend to run GPU-dependent workflows in the compute environment. Note that:
+
+    - The **Enable GPUs** setting does not cause GPU instances to deploy in your compute environment. You must still specify GPU-enabled instance types in the **Advanced options > Instance types** field. 
+    - The **Enable GPUs** setting causes Forge to specify the most current [AWS-recommended GPU-optimized ECS AMI](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html) as the EC2 fleet AMI when creating the compute environment. 
+    - This setting can be overridden by **AMI Id** in the advanced options.
 
 15. Enter any additional **Allowed S3 buckets** that your workflows require to read input data or write output data. The **Pipeline work directory** bucket above is added by default to the list of **Allowed S3 buckets**.
 
@@ -167,10 +168,13 @@ Jump to the documentation for [Launching Pipelines](../launch/launchpad.md).
 
 - You can configure your custom networking setup using the **VPC**, **Subnets** and **Security groups** fields.
 
-- You can use your own **AMI**.
+- You can specify a custom **AMI Id**.
 
     !!! warning "Requirements for custom AMI"
-        To use a custom AMI, make sure the AMI is based on an Amazon Linux-2 ECS optimized image that meets the Batch requirements. To learn more about approved versions of the Amazon ECS optimized AMI, visit [this link](https://docs.aws.amazon.com/batch/latest/userguide/compute_resource_AMIs.html#batch-ami-spec)
+        To use a custom AMI, make sure the AMI is based on an Amazon Linux-2 ECS optimized image that meets the Batch requirements. To learn more about approved versions of the Amazon ECS optimized AMI, see [this AWS guide](https://docs.aws.amazon.com/batch/latest/userguide/compute_resource_AMIs.html#batch-ami-spec)
+
+    !!! warning "GPU-enabled AMI"
+        If a custom AMI is specified and the **Enable GPU** option is also selected, the custom AMI will be used instead of the AWS-recommended GPU-optimized AMI.
 
 - If you need to debug the EC2 instance provisioned by AWS Batch, specify a **Key pair** to login to the instance via SSH.
 

--- a/docs/compute-envs/azure-batch.md
+++ b/docs/compute-envs/azure-batch.md
@@ -84,9 +84,6 @@ When you open [this link](https://portal.azure.com/#blade/HubsExtension/BrowseRe
 
 4. Select **Create** to create the Azure Batch account.
 
-!!! note "Congratulations!"
-    You have completed the Azure environment setup for Tower.
-
 
 ### Compute Environment
 
@@ -127,7 +124,7 @@ Once the Azure resources are set up, we can add a new **Azure Batch** environmen
 
     ![](_images/azure_tower_forge.png)
 
-10. Enter the default VM type depending on your quota limits. The default is `Standard_D4_v3`.
+10. Enter the default VM type depending on your quota limits. The default is `Standard_D4_v3`. 
 
 11. Enter the **VMs count**, which is the number of VMs you'd like to deploy.
 
@@ -181,7 +178,7 @@ To create a new compute environment for AWS Batch (without Forge):
 8. Enter the **Pipeline work directory** as the Azure blob container we created in the previous section, e.g. `az://towerrgstorage-container/work`.
 
     !!! warning
-        The blob container should be in the same **Region** from the previous step.
+        The blob container should be in the same **Region** you specified in step 7 above.
 
 9. Set the **Config mode** to **Manual**.
 

--- a/docs/compute-envs/google-cloud-lifesciences.md
+++ b/docs/compute-envs/google-cloud-lifesciences.md
@@ -100,9 +100,6 @@ You can manage your key from the **Service Accounts** page.
     - Storage Legacy Object Owner
     - Storage Object Creator
 
-!!! tip "Congratulations!"
-    You have created a project, enabled the necessary Google APIs, created a bucket, and created a JSON file with the required credentials. You are now ready to set up a new compute environment in Tower.
-
 
 ## Compute Environment
 

--- a/docs/compute-envs/overview.md
+++ b/docs/compute-envs/overview.md
@@ -37,5 +37,9 @@ If you have more than one compute environment, you can select which one will be 
 
 2. Select **Make primary** for a particular compute environment to make it your default.   
 
-!!! tip "Congratulations!" 
-    You are now ready to launch pipelines with your primary compute environment.
+
+## GPU usage
+
+The process for provisioning GPU instances in your compute environment differs for each cloud provider:
+
+See [AWS Batch](./aws-batch.md#compute-environment14)

--- a/docs/credentials/aws_registry_credentials.md
+++ b/docs/credentials/aws_registry_credentials.md
@@ -6,9 +6,11 @@ description: 'Step-by-step instructions to set up AWS ECR credentials in Nextflo
 
 ### Registry credentials 
 
-From version 22.3, Tower supports the configuration of credentials for container registry services. AWS ECR makes use of IAM user roles for access control, so authentication depends on how your ECR instance is configured and used. For further details, see [ECR Identity and Access Management](https://docs.aws.amazon.com/AmazonECR/latest/userguide/security-iam.html). Your ECR credentials can be configured in Tower from the Credentials tab:
+From version 22.3, Tower supports the configuration of credentials for container registry services. These credentials are leveraged by the Nextflow Wave container service to authenticate to private container registries. For more information on Wave containers, see [here](https://www.nextflow.io/docs/latest/wave.html).
 
-**1.** Select **Add Credentials**. 
+AWS ECR makes use of IAM user roles for access control, so authentication depends on your ECR instance configuration. For further details, see [ECR Identity and Access Management](https://docs.aws.amazon.com/AmazonECR/latest/userguide/security-iam.html). Once you have set up an IAM user with permissions to access your ECR instance, add the user's credentials to Tower using these steps:
+
+**1.** Navigate to the Credentials tab and select **Add Credentials**. 
 
 **2.** Enter a unique name in the **Name** field using alphanumeric characters, dashes, or underscores. 
 
@@ -16,8 +18,10 @@ From version 22.3, Tower supports the configuration of credentials for container
 
 ![](_images/container_registry_credentials_blank.png)
 
-**4.** Enter the details of the AWS user — with the appropriate IAM role to access the registry — using the **User name** and **Password** fields.
+**4.** Enter the user's details to the **User name** and **Password** fields.
 
 **6.** Enter your registry hostname in the **Registry server** field.
 
 **7.** Select **Add**. The new credential is now listed under the **Credentials** tab.
+
+**8.** In order for your pipeline execution to leverage Wave containers, add `wave { enabled=true }` to the **Nextflow config** field on the launch page. 

--- a/docs/credentials/aws_registry_credentials.md
+++ b/docs/credentials/aws_registry_credentials.md
@@ -8,7 +8,7 @@ description: 'Step-by-step instructions to set up AWS ECR credentials in Nextflo
 
 From version 22.3, Tower supports the configuration of credentials for container registry services. These credentials are leveraged by the Nextflow Wave container service to authenticate to private container registries. For more information on Wave containers, see [here](https://www.nextflow.io/docs/latest/wave.html).
 
-AWS ECR makes use of IAM user roles for access control, so authentication depends on your ECR instance configuration. For further details, see [ECR Identity and Access Management](https://docs.aws.amazon.com/AmazonECR/latest/userguide/security-iam.html). Once you have set up an IAM user with permissions to access your ECR instance, add the user's credentials to Tower using these steps:
+AWS ECR makes use of IAM user roles for access control. Note that [long-term access keys](https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#create-long-term-access-keys) must be used to authenticate Tower to your registry. This must be stored as a **Container registry** credential, even if the same access keys already exist in Tower as a [workspace credential](./workspace_credentials.md). Once you have set up an IAM user with permissions to access your ECR registry, add the user's credentials to Tower using these steps:
 
 **1.** Navigate to the Credentials tab and select **Add Credentials**. 
 
@@ -18,10 +18,12 @@ AWS ECR makes use of IAM user roles for access control, so authentication depend
 
 ![](_images/container_registry_credentials_blank.png)
 
-**4.** Enter the user's details to the **User name** and **Password** fields.
+**4.** Enter the user access key ID in the **User name** field. 
+
+**5.** Enter the user secret access key in the **Password** field. 
 
 **6.** Enter your registry hostname in the **Registry server** field.
 
 **7.** Select **Add**. The new credential is now listed under the **Credentials** tab.
 
-**8.** In order for your pipeline execution to leverage Wave containers, add `wave { enabled=true }` to the **Nextflow config** field on the launch page. 
+**8.** In order for your pipeline execution to leverage Wave containers, add `wave { enabled=true }` either to the **Nextflow config** field on the launch page, or to your nextflow.config file. 

--- a/docs/credentials/azure_registry_credentials.md
+++ b/docs/credentials/azure_registry_credentials.md
@@ -10,24 +10,26 @@ From version 22.3, Tower supports the configuration of credentials for container
 
 Azure container registry makes use of Azure RBAC (Role-Based Access Control) to grant users access — for further details, see [Azure container registry roles and permissions](https://learn.microsoft.com/en-us/azure/container-registry/container-registry-roles). 
 
-We recommend using Azure credentials with long-term registry access to authenticate Tower to your registry. For this purpose, use the Azure portal to enable the Admin user in your container registry from **Settings > Access keys**. 
+You must use Azure credentials with long-term registry access to authenticate Tower to your registry. For this purpose, use  
 
-The container registry credentials can be configured in Tower using these steps:
+To create the container registry credentials in Tower, follow these steps:
 
-**1.** Navigate to the Credentials tab and select **Add Credentials**. 
+**1.** In the Azure container registry portal, enable the Admin user for your registry from **Settings > Access keys**.
 
-**2.** Enter a unique name in the **Name** field using alphanumeric characters, dashes, or underscores. 
+**2.** In Tower, navigate to the Credentials tab and select **Add Credentials**. 
 
-**3.** From the **Provider** drop-down list, select **Container registry**. The New Credentials form now displays additional fields to be completed: 
+**3.** Enter a unique name in the **Name** field using alphanumeric characters, dashes, or underscores. 
+
+**4.** From the **Provider** drop-down list, select **Container registry**. The New Credentials form now displays additional fields to be completed: 
 
 ![](_images/container_registry_credentials_blank.png)
 
-**4.** Enter the admin user's username in the **User name** field. 
+**5.** Enter the admin user's username in the **User name** field. 
 
-**5.** Enter a password in the **Password** field.
+**6.** Enter an admin user password in the **Password** field.
 
-**6.** Enter the container registry hostname in the **Registry server** field. This is the **Login server** name on your container registry's **Settings > Access keys** page in Azure portal. 
+**7.** Enter the container registry hostname in the **Registry server** field. This is the **Login server** name on your container registry's **Settings > Access keys** page in Azure portal. 
 
-**7.** Select **Add**. The new credential is now listed under the **Credentials** tab.
+**8.** Select **Add**. The new credential is now listed under the **Credentials** tab.
 
-**8.** In order for your pipeline execution to leverage Wave containers, add `wave { enabled=true }` either to the **Nextflow config** field on the launch page, or to your nextflow.config file. 
+**9.** In order for your pipeline execution to leverage Wave containers, add `wave { enabled=true }` either to the **Nextflow config** field on the launch page, or to your nextflow.config file. 

--- a/docs/credentials/azure_registry_credentials.md
+++ b/docs/credentials/azure_registry_credentials.md
@@ -10,7 +10,9 @@ From version 22.3, Tower supports the configuration of credentials for container
 
 Azure container registry makes use of Azure RBAC (Role-Based Access Control) to grant users access — for further details, see [Azure container registry roles and permissions](https://learn.microsoft.com/en-us/azure/container-registry/container-registry-roles). 
 
-Once you have granted a user the appropriate permissions to access your registry, Azure provides a number of options for authenticating to the registry (such as [individual login or Azure AD](https://learn.microsoft.com/en-us/azure/container-registry/container-registry-authentication?tabs=azure-cli)). Using the access token you created with the Azure CLI commands described in the articles above, the registry credentials can be configured in Tower using these steps:
+We recommend using Azure credentials with long-term registry access to authenticate Tower to your registry. For this purpose, use the Azure portal to enable the Admin user in your container registry from **Settings > Access keys**. 
+
+The container registry credentials can be configured in Tower using these steps:
 
 **1.** Navigate to the Credentials tab and select **Add Credentials**. 
 
@@ -20,12 +22,12 @@ Once you have granted a user the appropriate permissions to access your registry
 
 ![](_images/container_registry_credentials_blank.png)
 
-**4.** Enter `00000000-0000-0000-0000-000000000000` in the **User name** field. 
+**4.** Enter the admin user's username in the **User name** field. 
 
-**5.** Enter the access token (`accessToken` — received when the `az acr login` command was run) in the **Password** field. 
+**5.** Enter a password in the **Password** field.
 
-**6.** Enter the container registry hostname in the **Registry server** field.
+**6.** Enter the container registry hostname in the **Registry server** field. This is the **Login server** name on your container registry's **Settings > Access keys** page in Azure portal. 
 
 **7.** Select **Add**. The new credential is now listed under the **Credentials** tab.
 
-**8.** In order for your pipeline execution to leverage Wave containers, add `wave { enabled=true }` to the **Nextflow config** field on the launch page. 
+**8.** In order for your pipeline execution to leverage Wave containers, add `wave { enabled=true }` either to the **Nextflow config** field on the launch page, or to your nextflow.config file. 

--- a/docs/credentials/azure_registry_credentials.md
+++ b/docs/credentials/azure_registry_credentials.md
@@ -6,9 +6,13 @@ description: 'Step-by-step instructions to set up Azure container registry crede
 
 ### Container registry credentials 
 
-From version 22.3, Tower supports the configuration of credentials for container registry services. Azure container registry grants access to users with appropriate permissions — for further details, see [Azure container registry roles and permissions](https://learn.microsoft.com/en-us/azure/container-registry/container-registry-roles). Your Azure registry credentials can be configured in Tower from the Credentials tab using these steps:
+From version 22.3, Tower supports the configuration of credentials for container registry services. These credentials are leveraged by the Nextflow Wave container service to authenticate to private container registries. For more information on Wave containers, see [here](https://www.nextflow.io/docs/latest/wave.html).
 
-**1.** Select **Add Credentials**. 
+Azure container registry makes use of Azure RBAC (Role-Based Access Control) to grant users access — for further details, see [Azure container registry roles and permissions](https://learn.microsoft.com/en-us/azure/container-registry/container-registry-roles). 
+
+Once you have granted a user the appropriate permissions to access your registry, Azure provides a number of options for authenticating to the registry (such as [individual login or Azure AD](https://learn.microsoft.com/en-us/azure/container-registry/container-registry-authentication?tabs=azure-cli)). Using the access token you created with the Azure CLI commands described in the articles above, the registry credentials can be configured in Tower using these steps:
+
+**1.** Navigate to the Credentials tab and select **Add Credentials**. 
 
 **2.** Enter a unique name in the **Name** field using alphanumeric characters, dashes, or underscores. 
 
@@ -16,10 +20,12 @@ From version 22.3, Tower supports the configuration of credentials for container
 
 ![](_images/container_registry_credentials_blank.png)
 
-**4.** Enter the credentials — to be used to access the container registry — starting with the **User name**.
+**4.** Enter `00000000-0000-0000-0000-000000000000` in the **User name** field. 
 
-**5.** Enter the Access Key in the **Password** field.
+**5.** Enter the access token (`accessToken` — received when the `az acr login` command was run) in the **Password** field. 
 
 **6.** Enter the container registry hostname in the **Registry server** field.
 
 **7.** Select **Add**. The new credential is now listed under the **Credentials** tab.
+
+**8.** In order for your pipeline execution to leverage Wave containers, add `wave { enabled=true }` to the **Nextflow config** field on the launch page. 

--- a/docs/credentials/docker_hub_registry_credentials.md
+++ b/docs/credentials/docker_hub_registry_credentials.md
@@ -8,6 +8,8 @@ description: 'Step-by-step instructions to set up Docker container registry cred
 
 From version 22.3, Tower supports the configuration of credentials for container registry services. These credentials are leveraged by the Nextflow Wave container service to authenticate to private container registries. For more information on Wave containers, see [here](https://www.nextflow.io/docs/latest/wave.html).
 
+Docker Hub makes use of Personal Access Tokens for authentication and also supports [two-factor authentication](https://docs.docker.com/docker-hub/2fa/). If you have 2FA enabled for your Docker Hub user account, you will be asked for a security code from the authenticator app configured in your account every time Tower uses your credentials to access your registry. 
+
 To create your new Docker Hub registry credential in Tower, follow these steps:
 
 **1.** Create a [Personal Access Token](https://docs.docker.com/docker-hub/access-tokens/) for your user account in Docker Hub.

--- a/docs/credentials/docker_hub_registry_credentials.md
+++ b/docs/credentials/docker_hub_registry_credentials.md
@@ -8,7 +8,7 @@ description: 'Step-by-step instructions to set up Docker container registry cred
 
 From version 22.3, Tower supports the configuration of credentials for container registry services. These credentials are leveraged by the Nextflow Wave container service to authenticate to private container registries. For more information on Wave containers, see [here](https://www.nextflow.io/docs/latest/wave.html).
 
-Docker Hub makes use of Personal Access Tokens for authentication and also supports [two-factor authentication](https://docs.docker.com/docker-hub/2fa/). If you have 2FA enabled for your Docker Hub user account, you will be asked for a security code from the authenticator app configured in your account every time Tower uses your credentials to access your registry. 
+Docker Hub makes use of Personal Access Tokens for authentication. Note that we do not currently support Docker Hub authentication using 2FA (two-factor authentication).
 
 To create your new Docker Hub registry credential in Tower, follow these steps:
 

--- a/docs/credentials/docker_hub_registry_credentials.md
+++ b/docs/credentials/docker_hub_registry_credentials.md
@@ -28,4 +28,4 @@ To create your new Docker Hub registry credential in Tower, follow these steps:
 
 **8.** Select **Add**. The new credential is now listed under the **Credentials** tab.
 
-**9.** In order for your pipeline execution to leverage Wave containers, add `wave { enabled=true }` to the **Nextflow config** field on the launch page. 
+**9.** In order for your pipeline execution to leverage Wave containers, add `wave { enabled=true }` either to the **Nextflow config** field on the launch page, or to your nextflow.config file. 

--- a/docs/credentials/docker_registry_credentials.md
+++ b/docs/credentials/docker_registry_credentials.md
@@ -6,20 +6,26 @@ description: 'Step-by-step instructions to set up Docker container registry cred
 
 ### Container registry credentials 
 
-From version 22.3, Tower supports the configuration of credentials for container registry services. Docker Hub container credentials make use of [Personal Access Tokens](https://docs.docker.com/docker-hub/access-tokens/). Your Docker Hub credentials can be configured in Tower from the Credentials tab:
+From version 22.3, Tower supports the configuration of credentials for container registry services. These credentials are leveraged by the Nextflow Wave container service to authenticate to private container registry services. For more information on Wave containers, see [here](https://www.nextflow.io/docs/latest/wave.html).
 
-**1.** Select **Add Credentials**. 
+To create your new Docker Hub registry credential in Tower, follow these steps:
 
-**2.** Enter a unique name in the **Name** field using alphanumeric characters, dashes, or underscores. 
+**1.** Create a [Personal Access Token](https://docs.docker.com/docker-hub/access-tokens/) for your user account in Docker Hub.
 
-**3.** From the **Provider** drop-down list, select **Container registry**. The New Credentials form now displays additional fields to be completed: 
+**2.** In Tower, navigate to the Credentials tab and select **Add Credentials**. 
+
+**3.** Enter a unique name in the **Name** field using alphanumeric characters, dashes, or underscores. 
+
+**4.** From the **Provider** drop-down list, select **Container registry**. The New Credentials form now displays additional fields to be completed: 
 
 ![](_images/container_registry_credentials_blank.png)
 
-**4.** Enter the credentials to be used to access the container registry, starting with the **User name**.
+**5.** Enter the credentials to be used to access the container registry, starting with the **User name**.
 
-**5.** Enter the Personal Access Token in the **Password** field.
+**6.** Enter the Personal Access Token in the **Password** field.
 
-**6.** (Optional) Enter _docker.io_ in the **Registry server** field.
+**7.** (Optional) Enter _docker.io_ in the **Registry server** field.
 
-**7.** Select **Add**. The new credential is now listed under the **Credentials** tab.
+**8.** Select **Add**. The new credential is now listed under the **Credentials** tab.
+
+**9.** In order for your pipeline execution to leverage Wave containers, add `wave { enabled=true }` to the **Nextflow config** field on the launch page. 

--- a/docs/credentials/docker_registry_credentials.md
+++ b/docs/credentials/docker_registry_credentials.md
@@ -6,7 +6,7 @@ description: 'Step-by-step instructions to set up Docker container registry cred
 
 ### Container registry credentials 
 
-From version 22.3, Tower supports the configuration of credentials for container registry services. These credentials are leveraged by the Nextflow Wave container service to authenticate to private container registry services. For more information on Wave containers, see [here](https://www.nextflow.io/docs/latest/wave.html).
+From version 22.3, Tower supports the configuration of credentials for container registry services. These credentials are leveraged by the Nextflow Wave container service to authenticate to private container registries. For more information on Wave containers, see [here](https://www.nextflow.io/docs/latest/wave.html).
 
 To create your new Docker Hub registry credential in Tower, follow these steps:
 
@@ -20,11 +20,11 @@ To create your new Docker Hub registry credential in Tower, follow these steps:
 
 ![](_images/container_registry_credentials_blank.png)
 
-**5.** Enter the credentials to be used to access the container registry, starting with the **User name**.
+**5.** Enter the Docker username in the **User name** field.
 
 **6.** Enter the Personal Access Token in the **Password** field.
 
-**7.** (Optional) Enter _docker.io_ in the **Registry server** field.
+**7.** (Optional) Enter `docker.io` in the **Registry server** field.
 
 **8.** Select **Add**. The new credential is now listed under the **Credentials** tab.
 

--- a/docs/credentials/google_registry_credentials.md
+++ b/docs/credentials/google_registry_credentials.md
@@ -6,7 +6,7 @@ description: 'Step-by-step instructions to set up Google Cloud Artifact Registry
 
 ### Registry credentials 
 
-From version 22.3, Tower supports the configuration of credentials for container registry services. These credentials are leveraged by the Nextflow Wave container service to authenticate to private container registry services. For more information on Wave containers, see [here](https://www.nextflow.io/docs/latest/wave.html).
+From version 22.3, Tower supports the configuration of credentials for container registry services. These credentials are leveraged by the Nextflow Wave container service to authenticate to private container registries. For more information on Wave containers, see [here](https://www.nextflow.io/docs/latest/wave.html).
 
 Google Cloud Artifact Registry is fully integrated with Google Cloud services and integration with third party tools can also be configured, so authentication depends on your repository configuration. For further details, see [Google Artifact Registry access control](https://cloud.google.com/artifact-registry/docs/access-control). 
 

--- a/docs/credentials/google_registry_credentials.md
+++ b/docs/credentials/google_registry_credentials.md
@@ -6,18 +6,24 @@ description: 'Step-by-step instructions to set up Google Cloud Artifact Registry
 
 ### Registry credentials 
 
-From version 22.3, Tower supports the configuration of credentials for container registry services. Google Cloud Artifact Registry is fully integrated with Google Cloud services and integration with third party tools can be configured, so authentication depends on how your Artifact Registry repository is configured. For further details, see [Google Artifact Registry access control](https://cloud.google.com/artifact-registry/docs/access-control). Your Google registry credentials can be configured in Tower from the Credentials tab:
+From version 22.3, Tower supports the configuration of credentials for container registry services. Google Cloud Artifact Registry is fully integrated with Google Cloud services and integration with third party tools can be configured, so authentication depends on how your Artifact Registry repository is configured. For further details, see [Google Artifact Registry access control](https://cloud.google.com/artifact-registry/docs/access-control). 
 
-**1.** Select **Add Credentials**. 
+To create your new registry credential in Tower, follow these steps:
 
-**2.** Enter a unique name in the **Name** field using alphanumeric characters, dashes, or underscores. 
+**1.** Create a [Google Service account key](https://cloud.google.com/artifact-registry/docs/docker/authentication#json-key) that has permissions to access Google Artifact Registry. 
 
-**3.** From the **Provider** drop-down list, select **Container registry**. The New Credentials form now displays additional fields to be completed: 
+**2.** Navigate to the Credentials tab in Tower and select **Add Credentials**. 
+
+**3.** Enter a unique name in the **Name** field using alphanumeric characters, dashes, or underscores. 
+
+**4.** From the **Provider** drop-down list, select **Container registry**. The New Credentials form now displays additional fields to be completed: 
 
 ![](_images/container_registry_credentials_blank.png)
 
-**4.** Enter the details of the Artifact Registry service account — with the appropriate IAM role to access the registry — using the **User name** and **Password** fields.
+**5.** Enter `_json_key_base64` in the **User name** field.
 
-**6.** Enter your registry hostname in the **Registry server** field.
+**6.** Enter the base64-encoded JSON key content in the **Password** field. 
 
-**7.** Select **Add**. The new credential is now listed under the **Credentials** tab.
+**7.** Enter your registry hostname in the **Registry server** field.
+
+**8.** Select **Add**. The new credential is now listed under the **Credentials** tab.

--- a/docs/credentials/google_registry_credentials.md
+++ b/docs/credentials/google_registry_credentials.md
@@ -6,7 +6,9 @@ description: 'Step-by-step instructions to set up Google Cloud Artifact Registry
 
 ### Registry credentials 
 
-From version 22.3, Tower supports the configuration of credentials for container registry services. Google Cloud Artifact Registry is fully integrated with Google Cloud services and integration with third party tools can be configured, so authentication depends on how your Artifact Registry repository is configured. For further details, see [Google Artifact Registry access control](https://cloud.google.com/artifact-registry/docs/access-control). 
+From version 22.3, Tower supports the configuration of credentials for container registry services. These credentials are leveraged by the Nextflow Wave container service to authenticate to private container registry services. For more information on Wave containers, see [here](https://www.nextflow.io/docs/latest/wave.html).
+
+Google Cloud Artifact Registry is fully integrated with Google Cloud services and integration with third party tools can also be configured, so authentication depends on your repository configuration. For further details, see [Google Artifact Registry access control](https://cloud.google.com/artifact-registry/docs/access-control). 
 
 To create your new registry credential in Tower, follow these steps:
 
@@ -27,3 +29,5 @@ To create your new registry credential in Tower, follow these steps:
 **7.** Enter your registry hostname in the **Registry server** field.
 
 **8.** Select **Add**. The new credential is now listed under the **Credentials** tab.
+
+**9.** In order for your pipeline execution to leverage Wave containers, add `wave { enabled=true }` to the **Nextflow config** field on the launch page. 

--- a/docs/credentials/google_registry_credentials.md
+++ b/docs/credentials/google_registry_credentials.md
@@ -1,18 +1,18 @@
 ---
-title: Google Cloud Artifact Registry credentials
-headline: 'Google Cloud Artifact Registry credentials'
-description: 'Step-by-step instructions to set up Google Cloud Artifact Registry credentials in Nextflow Tower.'
+title: Google Cloud Artifact Registry and Container Registry credentials
+headline: 'Google Cloud Artifact Registry and Container Registry credentials'
+description: 'Step-by-step instructions to set up Google Cloud Artifact Registry and Container Registry credentials in Nextflow Tower.'
 ---
 
 ### Registry credentials 
 
 From version 22.3, Tower supports the configuration of credentials for container registry services. These credentials are leveraged by the Nextflow Wave container service to authenticate to private container registries. For more information on Wave containers, see [here](https://www.nextflow.io/docs/latest/wave.html).
 
-Google Cloud Artifact Registry is fully integrated with Google Cloud services and integration with third party tools can also be configured, so authentication depends on your repository configuration. For further details, see [Google Artifact Registry access control](https://cloud.google.com/artifact-registry/docs/access-control). 
+Google Cloud Artifact Registry and Google Cloud Container Registry are fully integrated with Google Cloud services and support various authentication methods. Note that long-lived service account keys (in the form of JSON key files) must be used to authenticate Tower to your registry. For more information, see [Container Registry authentication](https://cloud.google.com/container-registry/docs/advanced-authentication#json-key) or [Artifact Registry authentication](https://cloud.google.com/artifact-registry/docs/docker/authentication#json-key).
 
 To create your new registry credential in Tower, follow these steps:
 
-**1.** Create a [Google Service account key](https://cloud.google.com/artifact-registry/docs/docker/authentication#json-key) that has permissions to access Google Artifact Registry. 
+**1.** Create a Google Service account key that has permissions to access your registry (see the Google registry-specific guides linked above). 
 
 **2.** Navigate to the Credentials tab in Tower and select **Add Credentials**. 
 
@@ -30,4 +30,4 @@ To create your new registry credential in Tower, follow these steps:
 
 **8.** Select **Add**. The new credential is now listed under the **Credentials** tab.
 
-**9.** In order for your pipeline execution to leverage Wave containers, add `wave { enabled=true }` to the **Nextflow config** field on the launch page. 
+**9.** In order for your pipeline execution to leverage Wave containers, add `wave { enabled=true }` either to the **Nextflow config** field on the launch page, or to your nextflow.config file. 

--- a/docs/credentials/quay_registry_credentials.md
+++ b/docs/credentials/quay_registry_credentials.md
@@ -24,4 +24,4 @@ You grant users access to your Quay deployment using the AUTHENTICATION_TYPE spe
 
 **6.** Select **Add**. The new credential is now listed under the **Credentials** tab.
 
-**7.** In order for your pipeline execution to leverage Wave containers, add `wave { enabled=true }` to the **Nextflow config** field on the launch page. 
+**7.** In order for your pipeline execution to leverage Wave containers, add `wave { enabled=true }` either to the **Nextflow config** field on the launch page, or to your nextflow.config file. 

--- a/docs/credentials/quay_registry_credentials.md
+++ b/docs/credentials/quay_registry_credentials.md
@@ -8,7 +8,7 @@ description: 'Step-by-step instructions to set up Quay container credentials in 
 
 From version 22.3, Tower supports the configuration of credentials for container registry services. These credentials are leveraged by the Nextflow Wave container service to authenticate to private container registries. For more information on Wave containers, see [here](https://www.nextflow.io/docs/latest/wave.html).
 
-You grant users access to your Quay deployment using the AUTHENTICATION_TYPE specified in your [Quay configuration](https://docs.projectquay.io/config_quay.html#config-fields-required-general). Once set up, add the  credentials of a user with appropriate Quay access to Tower using these steps:
+For Quay repositories, we recommend using [robot accounts](https://docs.quay.io/glossary/robot-accounts.html) for authentication. Once set up with appropriate permissions, add the robot account's credentials to Tower using these steps:
 
 **1.** Navigate to the Credentials tab and select **Add Credentials**. 
 
@@ -18,10 +18,12 @@ You grant users access to your Quay deployment using the AUTHENTICATION_TYPE spe
 
 ![](_images/container_registry_credentials_blank.png)
 
-**4.** Enter the user's credentials to the **User name** and **Password** fields.
+**4.** Enter the robot account username (in the format `namespace+accountname`, i.e. `mycompany+deploy`) in the **User name** field. 
 
-**5.** Enter your server hostname in the **Registry server** field.
+**5.** Enter the robot account access token (found by selecting the robot account in your Quay admin panel) in the **Password** field. 
 
-**6.** Select **Add**. The new credential is now listed under the **Credentials** tab.
+**6.** Enter your registry hostname in the **Registry server** field.
 
-**7.** In order for your pipeline execution to leverage Wave containers, add `wave { enabled=true }` either to the **Nextflow config** field on the launch page, or to your nextflow.config file. 
+**7.** Select **Add**. The new credential is now listed under the **Credentials** tab.
+
+**8.** In order for your pipeline execution to leverage Wave containers, add `wave { enabled=true }` either to the **Nextflow config** field on the launch page, or to your nextflow.config file. 

--- a/docs/credentials/quay_registry_credentials.md
+++ b/docs/credentials/quay_registry_credentials.md
@@ -6,9 +6,11 @@ description: 'Step-by-step instructions to set up Quay container credentials in 
 
 ### Container registry credentials 
 
-From version 22.3, Tower supports the configuration of credentials for container registry services. Quay credentials depend on the authentication specified in your [Quay configuration](https://access.redhat.com/documentation/en-us/red_hat_quay) and are used to authenticate to your Quay deployment. Your Quay credentials can be configured in Tower from the Credentials tab:
+From version 22.3, Tower supports the configuration of credentials for container registry services. These credentials are leveraged by the Nextflow Wave container service to authenticate to private container registries. For more information on Wave containers, see [here](https://www.nextflow.io/docs/latest/wave.html).
 
-**1.** Select **Add Credentials**. 
+You grant users access to your Quay deployment using the AUTHENTICATION_TYPE specified in your [Quay configuration](https://docs.projectquay.io/config_quay.html#config-fields-required-general). Once set up, add the  credentials of a user with appropriate Quay access to Tower using these steps:
+
+**1.** Navigate to the Credentials tab and select **Add Credentials**. 
 
 **2.** Enter a unique name in the **Name** field using alphanumeric characters, dashes, or underscores. 
 
@@ -16,8 +18,10 @@ From version 22.3, Tower supports the configuration of credentials for container
 
 ![](_images/container_registry_credentials_blank.png)
 
-**4.** Enter the credentials configured in your `config.yaml` file in the **User name** and **Password** fields.
+**4.** Enter the user's credentials to the **User name** and **Password** fields.
 
 **5.** Enter your server hostname in the **Registry server** field.
 
-**7.** Select **Add**. The new credential is now listed under the **Credentials** tab.
+**6.** Select **Add**. The new credential is now listed under the **Credentials** tab.
+
+**7.** In order for your pipeline execution to leverage Wave containers, add `wave { enabled=true }` to the **Nextflow config** field on the launch page. 

--- a/docs/credentials/registry_credentials.md
+++ b/docs/credentials/registry_credentials.md
@@ -6,7 +6,7 @@ description: 'Step-by-step instructions to set up container registry credentials
 
 ## Introduction
 
-From version 22.4, Tower supports the configuration of credentials for container registry services. 
+From version 22.4, Tower supports the configuration of credentials for container registry services. These credentials are leveraged by the Wave container service to authenticate to private container registry services, such as Docker Hub, Google Artifact Registry, Quay, etc. 
 
 ### General instructions
 

--- a/docs/credentials/registry_credentials.md
+++ b/docs/credentials/registry_credentials.md
@@ -20,12 +20,10 @@ Using credentials, access tokens, or keys with permissions to access your regist
 
 ![](_images/container_registry_credentials_blank.png)
 
-**4.** Enter the credentials to be used to access the container registry, starting with the **User name**. For registry authentication using keys or access tokens (such as the JSON key file for Google Artifact Registry), this value must correspond to the variable where the key is set in your registry's configuration (e.g. `_json_key_base64`).
+**4.** Enter the credentials to be used to access the container registry, as described in the page specific to each target registry. 
 
-**5.** Enter the container registry credential **Password**. For registry authentication using keys or access tokens (such as the JSON key file for Google Artifact Registry), populate this field with the content of the key or access token. 
+**5.** Enter the container **Registry server** name. If left blank, _docker.io_ will be used by default.  
 
-**6.** Enter the container **Registry server** name. If left blank, _docker.io_ will be used by default.  
+**6.** Select **Add**. The new credential is now listed under the **Credentials** tab.
 
-**7.** Select **Add**. The new credential is now listed under the **Credentials** tab.
-
-**8.** In order for your pipeline execution to leverage Wave containers, add `wave { enabled=true }` to the **Nextflow config** field on the launch page. 
+**7.** In order for your pipeline execution to leverage Wave containers, add `wave { enabled=true }` either to the **Nextflow config** field on the launch page, or to your nextflow.config file. 

--- a/docs/credentials/registry_credentials.md
+++ b/docs/credentials/registry_credentials.md
@@ -6,11 +6,11 @@ description: 'Step-by-step instructions to set up container registry credentials
 
 ## Introduction
 
-From version 22.4, Tower supports the configuration of credentials for container registry services. These credentials are leveraged by the Nextflow Wave container service to authenticate to private container registry services, such as Docker Hub, Google Artifact Registry, Quay, etc. For more information on Wave containers, see [here](https://www.nextflow.io/blog/2022/rethinking-containers-for-cloud-native-pipelines.html). 
+From version 22.3, Tower supports the configuration of credentials for container registry services. These credentials are leveraged by the Nextflow Wave container service to authenticate to private container registries (such as Docker Hub, Google Artifact Registry, Quay, etc.) For more information on Wave containers, see [here](https://www.nextflow.io/docs/latest/wave.html). 
 
 ### General instructions
 
-Using credentials or keys with permissions to access your registry, you can create container registry credentials in Tower using these steps:
+Using credentials, access tokens, or keys with permissions to access your registry, you can create container registry credentials in Tower using these steps:
 
 **1.** Navigate to the Credentials tab and select **Add Credentials**. 
 
@@ -20,10 +20,12 @@ Using credentials or keys with permissions to access your registry, you can crea
 
 ![](_images/container_registry_credentials_blank.png)
 
-**4.** Enter the credentials to be used to access the container registry, starting with the **User name**.
+**4.** Enter the credentials to be used to access the container registry, starting with the **User name**. For registry authentication using keys or access tokens (such as the JSON key file for Google Artifact Registry), this value must correspond to the variable where the key is set in your registry's configuration (e.g. `_json_key_base64`).
 
-**5.** Enter the container registry credential **Password**. For registry authentication using keys (such as the JSON key file for Google Artifcate Registry), populate this field with the (base64-encoded) key content. 
+**5.** Enter the container registry credential **Password**. For registry authentication using keys or access tokens (such as the JSON key file for Google Artifact Registry), populate this field with the content of the key or access token. 
 
 **6.** Enter the container **Registry server** name. If left blank, _docker.io_ will be used by default.  
 
 **7.** Select **Add**. The new credential is now listed under the **Credentials** tab.
+
+**8.** In order for your pipeline execution to leverage Wave containers, add `wave { enabled=true }` to the **Nextflow config** field on the launch page. 

--- a/docs/credentials/registry_credentials.md
+++ b/docs/credentials/registry_credentials.md
@@ -6,13 +6,13 @@ description: 'Step-by-step instructions to set up container registry credentials
 
 ## Introduction
 
-From version 22.4, Tower supports the configuration of credentials for container registry services. These credentials are leveraged by the Wave container service to authenticate to private container registry services, such as Docker Hub, Google Artifact Registry, Quay, etc. 
+From version 22.4, Tower supports the configuration of credentials for container registry services. These credentials are leveraged by the Nextflow Wave container service to authenticate to private container registry services, such as Docker Hub, Google Artifact Registry, Quay, etc. For more information on Wave containers, see [here](https://www.nextflow.io/blog/2022/rethinking-containers-for-cloud-native-pipelines.html). 
 
 ### General instructions
 
-Container registry credentials can be created from the Credentials tab using these steps:
+Using credentials or keys with permissions to access your registry, you can create container registry credentials in Tower using these steps:
 
-**1.** Select **Add Credentials**. 
+**1.** Navigate to the Credentials tab and select **Add Credentials**. 
 
 **2.** Enter a unique name in the **Name** field using alphanumeric characters, dashes, or underscores. 
 
@@ -22,7 +22,7 @@ Container registry credentials can be created from the Credentials tab using the
 
 **4.** Enter the credentials to be used to access the container registry, starting with the **User name**.
 
-**5.** Enter the container registry credential **Password**.
+**5.** Enter the container registry credential **Password**. For registry authentication using keys (such as the JSON key file for Google Artifcate Registry), populate this field with the (base64-encoded) key content. 
 
 **6.** Enter the container **Registry server** name. If left blank, _docker.io_ will be used by default.  
 

--- a/docs/credentials/registry_credentials.md
+++ b/docs/credentials/registry_credentials.md
@@ -20,7 +20,7 @@ Using credentials, access tokens, or keys with permissions to access your regist
 
 ![](_images/container_registry_credentials_blank.png)
 
-**4.** Enter the credentials to be used to access the container registry, as described in the page specific to each target registry. 
+**4.** Enter the credentials to be used to access the container registry, as described in the page specific to each target registry.
 
 **5.** Enter the container **Registry server** name. If left blank, _docker.io_ will be used by default.  
 

--- a/docs/faqs.md
+++ b/docs/faqs.md
@@ -125,6 +125,14 @@ The behaviour is patched in [Nextflow v22.09.7-edge](https://github.com/nextflow
 This error can occur if you execute a DSL 1-based Nextflow workflow using [Nextflow 22.03.0-edge](https://github.com/nextflow-io/nextflow/releases/tag/v22.03.0-edge) or later.
 
 
+**<p data-question>Q: Does the sleep command work the same way across my entire script?</p>**
+
+The `sleep` commands within your Nextflow workflows may differ in behaviour depending on where they are:
+
+- If used within an `errorStrategy` block, the Groovy sleep function will be used (which takes its value in milliseconds).
+- If used within a process script block, that language's sleep binary/method will be used. **Example:** [this BASH script](https://www.nextflow.io/docs/latest/metrics.html?highlight=sleep) uses the BASH sleep binary,  which takes its value in seconds.
+
+
 ### Compute Environments
 
 **<p data-question>Q: Can the name of a Compute Environment created in Tower contain special characters?**
@@ -688,6 +696,19 @@ No. You can inject values directly into `tower.yml` or - in the case of a Kubern
 Please contact Seqera Labs for more details if this is of interest.
 
 
+### Tower Forge
+
+**<p data-question>Q: What does the `Enable GPU` option do when building an AWS Batch cluster via Tower Forge?</p>**
+
+Activating the **Enable GPU** field while creating an AWS Batch environment with Tower Forge will result in an [AWS-recommended GPU-optimized ECS AMI](https://docs.aws.amazon.com/batch/latest/userguide/batch-gpu-ami.html) being used as your Batch cluster's default image. 
+
+Note:
+
+1. Activation does not cause GPU-enabled instances to automatically spawn in your Batch cluster. You must still specify these in the Forge screen's **Advanced options > Instance types** field.
+2. Population of the Forge screen's **Advanced options > AMI Id** field will supercede the AWS-recommended AMI. 
+3. Your Nextflow script must include [accelerator directives](https://www.nextflow.io/docs/latest/process.html?highlight=accelerator) to use the provisioned GPUs.
+
+
 ### tw CLI
 
 **<p data-question>Q: Can a custom run name be specified when launch a pipeline via the `tw` CLI?</p>**
@@ -912,6 +933,14 @@ This can occur if a tool/library in your task container requires SSL certificate
 You may be able to solve the issue by:
 
 1. Mounting host certificates into the container ([example](https://github.com/nextflow-io/nextflow/blob/v21.10.6/plugins/nf-azure/src/main/nextflow/cloud/azure/batch/AzBatchService.groovy#L348-L351)).
+
+
+**<p data-question>Q: Why is my deployment using Azure SQL database returning an error about `Connections using insecure transport are prohibited while --require_secure_transport=ON.`</p>**
+
+This is due to Azure's default MySQL behavior of enforcing the SSL connections between your server and client application, as detailed [here](https://learn.microsoft.com/en-us/azure/mysql/single-server/concepts-ssl-connection-security). In order to fix this, append the following to your `TOWER_DB_URL` connection string: `useSSL=true&enabledSslProtocolSuites=TLSv1.2&trustServerCertificate=true`
+
+eg, `TOWER_DB_URL=jdbc:mysql://azuredatabase.com/tower?serverTimezone=UTC&useSSL=true&enabledSslProtocolSuites=TLSv1.2&trustServerCertificate=true`
+
 
 
 ## Google


### PR DESCRIPTION
Added provider-specific instructions for registry credential creation to:
-AWS ECR
-Azure CR
-Docker Hub
-Google AR
-Quay

Added key and access token caveats to the container registry credentials overview page. 

Added Wave context (why and where container reg credentials are to be used) to all the above. 