### PR TITLE
Aggregate stats page cost estimate update

### DIFF
--- a/docs/monitoring/aggregate_stats.md
+++ b/docs/monitoring/aggregate_stats.md
@@ -10,8 +10,9 @@ The **Aggregate stats** panel displays a real-time summary of the resources used
 
 ![](_images/monitoring_aggregate_stats.png)
 
-The cost is only based on estimated computation usage and does not currently take into account storage or associated network costs. Tower has a database of costs for all cloud instances of AWS and Google Cloud in all regions and zones.
+Note that the cost estimate in Tower is a heuristic estimation of computation-only cost and is not intended to be a replacement for your cloud provider tooling (such as AWS Cost Explorer). Tower uses a database of costs for all cloud instances of AWS and Google Cloud in all regions and zones. This estimate does not currently take storage or associated network costs into account.
 
+The addition of [Resource labels](../resource-labels/overview.md) to your compute environments provides additional cost tracking through the annotation of the actual cloud resources consumed by a run. 
 
 ## Load and Utilization
 

--- a/docs/monitoring/aggregate_stats.md
+++ b/docs/monitoring/aggregate_stats.md
@@ -8,9 +8,11 @@ description: 'Statistics and resource usage of Nextflow pipelines executed throu
 
 The **Aggregate stats** panel displays a real-time summary of the resources used by the workflow. These include total running time ('wall time'), aggregated CPU time (CPU hours), memory usage (GB hours), data i/o and cost.
 
+### Estimated cost
+
 Note that the cost estimate in Tower is a heuristic estimation of computation-only cost and is not intended to be a replacement for your cloud provider tooling (such as AWS Cost Explorer). Tower uses a database of costs for all cloud instances of AWS and Google Cloud in all regions and zones. This estimate does not currently take storage or associated network costs into account.
 
-The addition of [Resource labels](../resource-labels/overview.md) to your compute environments provides additional cost tracking through the annotation of actual cloud resources consumed by a run.
+The addition of [Resource labels](../resource-labels/overview.md) to your compute environments provides additional cost tracking through annotation of the actual cloud resources consumed by a run.
 
 ![](_images/monitoring_aggregate_stats.png) 
 

--- a/docs/monitoring/aggregate_stats.md
+++ b/docs/monitoring/aggregate_stats.md
@@ -1,18 +1,18 @@
 ---
 title: Aggregate stats & load
 headline: 'Aggregate stats and resources'
-description: 'Statistics and resources usage of Nextflow pipelines executed through Tower.'
+description: 'Statistics and resource usage of Nextflow pipelines executed through Tower.'
 ---
 
 ## Aggregate Stats
 
 The **Aggregate stats** panel displays a real-time summary of the resources used by the workflow. These include total running time ('wall time'), aggregated CPU time (CPU hours), memory usage (GB hours), data i/o and cost.
 
-![](_images/monitoring_aggregate_stats.png)
-
 Note that the cost estimate in Tower is a heuristic estimation of computation-only cost and is not intended to be a replacement for your cloud provider tooling (such as AWS Cost Explorer). Tower uses a database of costs for all cloud instances of AWS and Google Cloud in all regions and zones. This estimate does not currently take storage or associated network costs into account.
 
-The addition of [Resource labels](../resource-labels/overview.md) to your compute environments provides additional cost tracking through the annotation of the actual cloud resources consumed by a run. 
+The addition of [Resource labels](../resource-labels/overview.md) to your compute environments provides additional cost tracking through the annotation of actual cloud resources consumed by a run.
+
+![](_images/monitoring_aggregate_stats.png) 
 
 ## Load and Utilization
 

--- a/docs/resource-labels/overview.md
+++ b/docs/resource-labels/overview.md
@@ -87,7 +87,7 @@ Resource labels can only be edited or deleted by admins and only if they are not
 This includes both compute environments and runs.
 The deletion of a resource label from a workspace has no influence on the cloud environment. 
 
-![](_images/label_management.png)
+![](_images/workflow-resource-labels.png)
 
 ## Limits
 


### PR DESCRIPTION
Per https://support.seqera.io/a/tickets/2143 . 

Updating the cost estimate statement on the Aggregate Stats page to include a caveat about the accuracy of that estimate, and point to resource labels as an additional way to track cloud costs more effectively. 