### PR TITLE
286 improve datasets documentation to highlight pipeline schema requirements

### DIFF
--- a/docs/datasets/overview.md
+++ b/docs/datasets/overview.md
@@ -8,7 +8,7 @@ description: 'Managing and using datasets in Nextflow Tower.'
 
 The **Datasets** feature in Nextflow Tower allows users to store CSV and TSV formatted dataset files in a workspace, to use as an input one or more pipelines. 
 
-In order for your pipeline to use your dataset as input during runtime, information about the dataset and file format must be included in the `input` parameters of your [pipeline-schema](/docs/pipeline-schema/overview.md). We recommend using the nf-core tools [schema build](https://nf-co.re/tools/#pipeline-schema) feature to simplify the schema creation process. Commands include an option to validate and lint your schema file according to best practice guidelines from the nf-core community. 
+In order for your pipeline to use your dataset as input during runtime, information about the dataset and file format must be included in the relevant parameters of your [pipeline-schema](/docs/pipeline-schema/overview.md). We recommend using the nf-core tools [schema build](https://nf-co.re/tools/#pipeline-schema) feature to simplify the schema creation process. Commands include an option to validate and lint your schema file according to best practice guidelines from the nf-core community. 
 
 
 ![](_images/datasets_listing.png)

--- a/docs/datasets/overview.md
+++ b/docs/datasets/overview.md
@@ -6,31 +6,33 @@ description: 'Managing and using datasets in Nextflow Tower.'
 
 ## Overview
 
-The **Datasets** functionality in Nextflow Tower allows the users to store CSV and TSV formatted files within a workspace and use those as an input one or more pipelines.
+The **Datasets** feature in Nextflow Tower allows users to store CSV and TSV formatted dataset files in a workspace, to use as an input one or more pipelines. 
+
+In order for your pipeline to use your dataset as input during runtime, information about the dataset and file format must be included in the `input` parameters of your [pipeline-schema](/pipeline-schema/overview). We recommend using the nf-core tools [schema build](https://nf-co.re/tools/#pipeline-schema) feature to simplify the schema creation process. Commands include an option to validate and lint your schema file according to best practice guidelines from the nf-core community. 
 
 
 ![](_images/datasets_listing.png)
 
 !!! note
-    This feature is available only in the [organization workspaces.](../orgs-and-teams/workspace-management.md).
+    This feature is only available in [organization workspaces](../orgs-and-teams/workspace-management.md).
 
 
 
 ## Creating a new Dataset
 
-To create a new dataset, please follow these steps 
+To create a new dataset, follow these steps:
 
 1. Open the `Datasets` tab in your organization workspace.
 
-2. Click on `New dataset` button to open the dataset creation dialog as shown below.
+2. Select `New dataset` to open the dataset creation dialog shown below.
 
 ![](_images/create_dataset.png)
 
-3. You can enter the **Name** and **Description** fields as per the nature of your dataset.
+3. Complete the **Name** and **Description** fields using information relevant to your dataset.
 
-4. You can add the dataset file to your workspace using either drag and drop or by using the system file explorer dialog.
+4. You can add the dataset file to your workspace using drag-and-drop, or the system file explorer dialog.
 
-5. It is possible to customize the subsequent views for the dataset using `First row as header` option, to accomodate the situations where the first row contains the column names.
+5. You can customize views for the dataset using the `First row as header` option, for dataset files that use the first row for column names.
 
 
 !!! warning
@@ -39,33 +41,31 @@ To create a new dataset, please follow these steps
 
 ## Dataset versions
 
-The **Datasets** functionality can accommodate multiple versions of a dataset. To add a new version for a dataset, please follow these steps 
+The **Datasets** feature can accommodate multiple versions of a dataset. To add a new version for a dataset, follow these steps:
 
-1. Click on the _Edit_ option for the intended dataset.
+1. Select **Edit** next to the dataset you wish to update.
 
-2. In the Edit dialog, click on the _Add a new version_ button.
+2. In the Edit dialog, select **Add a new version**.
 
-3. Upload the newer version of the dataset and click on _Update_.
+3. Upload the newer version of the dataset and select **Update**.
 
 !!! warning
-    All subsequent versions of a dataset must be in the same data format as the initial version of the dataset.
+    All subsequent versions of a dataset must be in the same data format as the initial version.
 
 
 ## Using a Dataset
 
-To use a dataset with the saved pipelines in your workspace, please follow these steps 
+To use a dataset with the saved pipelines in your workspace, follow these steps:
 
-1. Open any pipeline from the [Launchpad](/launch/launchpad) containing a [pipeline-schema](/pipeline-schema/overview).
+1. Open any pipeline that contains a [pipeline-schema](/pipeline-schema/overview) from the [Launchpad](/launch/launchpad).
 
-2. Click on the input field for the pipeline, removing any default value. 
+2. Select the input field for the pipeline, removing any default value. 
 
-3. Pick the right dataset for your pipeline
+3. Pick the desired dataset for your pipeline.
 
 
 ![](_images/datasets_dropdown.png)
 
 
 !!! warning
-    The Datasets shown in the dropdown menu depends upon the validation specified in your [pipeline-schema](/pipeline-schema/overview). Hence, if the schema specifies only `CSV` format, no `TSV` dataset would appear in the dropdown.
-
-
+    The datasets shown in the dropdown menu depend upon the validation in your [pipeline-schema](/pipeline-schema/overview). If the schema specifies only `CSV` format, no `TSV` dataset would appear in the dropdown.

--- a/docs/datasets/overview.md
+++ b/docs/datasets/overview.md
@@ -8,7 +8,7 @@ description: 'Managing and using datasets in Nextflow Tower.'
 
 The **Datasets** feature in Nextflow Tower allows users to store CSV and TSV formatted dataset files in a workspace, to use as an input one or more pipelines. 
 
-In order for your pipeline to use your dataset as input during runtime, information about the dataset and file format must be included in the `input` parameters of your [pipeline-schema](/pipeline-schema/overview). We recommend using the nf-core tools [schema build](https://nf-co.re/tools/#pipeline-schema) feature to simplify the schema creation process. Commands include an option to validate and lint your schema file according to best practice guidelines from the nf-core community. 
+In order for your pipeline to use your dataset as input during runtime, information about the dataset and file format must be included in the `input` parameters of your [pipeline-schema](/docs/pipeline-schema/overview.md). We recommend using the nf-core tools [schema build](https://nf-co.re/tools/#pipeline-schema) feature to simplify the schema creation process. Commands include an option to validate and lint your schema file according to best practice guidelines from the nf-core community. 
 
 
 ![](_images/datasets_listing.png)

--- a/docs/datasets/overview.md
+++ b/docs/datasets/overview.md
@@ -57,7 +57,7 @@ The **Datasets** feature can accommodate multiple versions of a dataset. To add 
 
 To use a dataset with the saved pipelines in your workspace, follow these steps:
 
-1. Open any pipeline that contains a [pipeline-schema](/pipeline-schema/overview) from the [Launchpad](/launch/launchpad).
+1. Open any pipeline that contains a [pipeline-schema](/docs/pipeline-schema/overview.md) from the [Launchpad](/docs/launch/launchpad.md).
 
 2. Select the input field for the pipeline, removing any default value. 
 
@@ -68,4 +68,4 @@ To use a dataset with the saved pipelines in your workspace, follow these steps:
 
 
 !!! warning
-    The datasets shown in the dropdown menu depend upon the validation in your [pipeline-schema](/pipeline-schema/overview). If the schema specifies only `CSV` format, no `TSV` dataset would appear in the dropdown.
+    The datasets shown in the dropdown menu depend upon the validation in your [pipeline-schema](/docs/pipeline-schema/overview.md). If the schema specifies only `CSV` format, no `TSV` dataset would appear in the dropdown.

--- a/docs/pipeline-schema/overview.md
+++ b/docs/pipeline-schema/overview.md
@@ -1,44 +1,43 @@
 ---
 title: Pipeline Schema
 headline: 'Pipeline Schema'
-description: 'A brief introduction to Pipeline Schema.'
+description: 'A brief introduction to pipeline schema.'
 ---
 
 ## Overview
 
-This page will give you a detailed description of what pipeline schema files are, why they are used, and show you how to build and customize your own Pipeline JSON schema file.
+This page provides an overview of what pipeline schema files are, why they are used, and how to build and customize your own pipeline JSON schema file.
 
 ![Tower Launch interface](_images/pipeline_schema_form.png)
 
 
-## What is a Pipeline schema?
+## What is a pipeline schema?
 
 Pipeline schema files describe the structure and validation constraints of your workflow parameters. They are used to validate parameters before launch to prevent software/pipelines failing in unexpected ways at runtime.
 
-Tower uses pipeline schema to build the launchpad parameters form.
+Tower uses the pipeline schema to build the launchpad parameters form.
 
 !!! tip
-    You can populate the parameters in the pipeline, by uploading a YAML or a JSON file, in addition to filling it on the UI itself.
+    You can populate the parameters in the pipeline by uploading a YAML or a JSON file, or in the Tower UI.
 
+See [here](https://github.com/nf-core/rnaseq/blob/e049f51f0214b2aef7624b9dd496a404a7c34d14/nextflow_schema.json) for an example of a pipeline schema file for the `nf-core/rnaseq` pipeline. 
 
 ## How can I build my own Pipeline schema file for my Nextflow pipelines?
 
-The pipeline schema is based on [json-schema.org](https://json-schema.org/) syntax, with some additional conventions. This can get complex, so we do not recommend creating or editing this file manually.
+The pipeline schema is based on [json-schema.org](https://json-schema.org/) syntax, with some additional conventions. While you can create your pipeline schema manually, we recommmend the use of [nf-core tools](https://nf-co.re/tools), a toolset for developing Nextflow pipelines.
 
-Instead, we recommmend using tools from the [nf-core](https://nf-co.re/) project, which provides a toolset for developing Nextflow pipelines.
-
-Running the `nf-core schema build` command in your pipeline root directory collects your pipeline parameters and gives you interactive prompts about missing or unexpected parameters. If no existing schema file is found, it will create one for you.
+When you run the `nf-core schema build` command in your pipeline root directory, the tool collects your pipeline parameters and gives you interactive prompts about missing or unexpected parameters. If no existing schema file is found, the tool will create one for you.
 
 For more information, please follow [this link](https://nf-co.re/tools/#build-a-pipeline-schema).
 
 
 ## How can I customise my schema file?
 
-Once the skeleton pipeline schema file has been built with the `nf-core schema build`, the command line tool will prompt you to open a [graphical schema editor](https://nf-co.re/pipeline_schema_builder) on the nf-core website.
+Once the skeleton pipeline schema file has been built with `nf-core schema build`, the command line tool will prompt you to open a [graphical schema editor](https://nf-co.re/pipeline_schema_builder) on the nf-core website.
 
 ![nf-core schema builder interface](./_images/pipeline_schema_overview.png)
 
-Leave the command-line tool running in the background - it checks the status of your schema on the website. When you click <kbd>Finished</kbd> on the website, it will automatically save your changes to the file locally.
+Leave the command-line tool running in the background - it checks the status of your schema on the website. When you select <kbd>Finished</kbd> on the schema editor page, it will save your changes to the schema file locally.
 
 
 ## Can I use the pipeline schema builder for pipelines outside of nf-core?

--- a/docs/pipeline-schema/overview.md
+++ b/docs/pipeline-schema/overview.md
@@ -28,7 +28,7 @@ The pipeline schema is based on [json-schema.org](https://json-schema.org/) synt
 
 When you run the `nf-core schema build` command in your pipeline root directory, the tool collects your pipeline parameters and gives you interactive prompts about missing or unexpected parameters. If no existing schema file is found, the tool will create one for you.
 
-For more information, please follow [this link](https://nf-co.re/tools/#build-a-pipeline-schema).
+For more information, see [this link](https://nf-co.re/tools/#build-a-pipeline-schema).
 
 
 ## How can I customise my schema file?


### PR DESCRIPTION
Address pipeline schema need on Datasets overview page and link to nf-core and Tower Help resources. 