### PR TITLE
Remove mkdocs material insiders

### DIFF
--- a/.github/workflows/staging-html.yml
+++ b/.github/workflows/staging-html.yml
@@ -43,7 +43,6 @@ jobs:
           # python -m pip install --upgrade pip setuptools wheel
           # python -m pip install mike
           pip install -r requirements.txt
-          python -m pip install "git+https://${{ secrets.GITEA_TOKEN }}@git.seqera.io/seqeralabs/mkdocs-material-insiders@7.3.3-insiders-3.1.3"
 
 
       - name: Build staging-html using mike

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -8,10 +8,7 @@ tasks:
       brew install python@3.9
       brew unlink python && brew link --overwrite python
       pip3 install --upgrade pip3
-      pip3.9 install -r requirements.txt &&
-      # The GITEA_TOKEN environment variable needs to be added to the Gitpod env variables by the user.
-      pip3.9 install "git+https://${GITEA_TOKEN}@git.seqera.io/seqeralabs/mkdocs-material-insiders@7.3.3-insiders-3.1.3"
-      brew install cairo
+      pip3 install -r requirements.txt
     command: mkdocs serve
 ports:
 - port: 8000

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,12 +6,16 @@ backcall==0.2.0
 backports.entry-points-selectable==1.1.0
 bandit==1.7.0
 bleach==4.1.0
+cairocffi==1.4.0
+CairoSVG==2.6.0
 certifi==2021.5.30
 cffi==1.14.6
 charset-normalizer==2.0.4
 click==8.0.3
 colorama==0.4.4
 cryptography==3.4.8
+cssselect2==0.7.0
+cssutils==2.6.0
 debugpy==1.4.3
 decorator==5.1.0
 defusedxml==0.7.1
@@ -45,7 +49,9 @@ mccabe==0.6.1
 mergedeep==1.3.4
 mike==1.1.2
 mistune==0.8.4
-mkdocs==1.2.3
+mkdocs==1.4.2
+mkdocs-material==9.0.12
+mkdocs-material-extensions==1.1.1
 mypy==0.910
 mypy-extensions==0.4.3
 nbclient==0.5.4
@@ -60,6 +66,7 @@ pbr==5.6.0
 pep8==1.7.1
 pexpect==4.8.0
 pickleshare==0.7.5
+Pillow==9.4.0
 pipenv==2022.1.8
 pkginfo==1.7.1
 platformdirs==2.3.0
@@ -70,9 +77,10 @@ pycodestyle==2.7.0
 pycparser==2.20
 pydocstyle==6.1.1
 pyflakes==2.3.1
-Pygments==2.12.0
+Pygments==2.14.0
 pylama==7.7.1
 pylint==2.10.2
+pymdown-extensions==9.9.2
 pyparsing==2.4.7
 pyrsistent==0.18.0
 python-dateutil==2.8.2
@@ -80,6 +88,7 @@ PyYAML==5.4.1
 pyyaml_env_tag==0.1
 pyzmq==22.2.1
 readme-renderer==29.0
+regex==2022.10.31
 requests==2.26.0
 requests-toolbelt==0.9.1
 rfc3986==1.5.0
@@ -92,6 +101,7 @@ snowballstemmer==2.1.0
 stevedore==3.4.0
 terminado==0.12.1
 testpath==0.5.0
+tinycss2==1.2.1
 toml==0.10.2
 tornado==6.1
 tqdm==4.62.2


### PR DESCRIPTION
This PR upgrades mkdocs-material so that we don't have to fetch the insiders version from Gitea. Presumably, whatever insiders features we were relying on have since been incorporated into the public version.

Since the upgrade installed some cairo packages, I also removed the extra cairo install command from the gitpod yml, just to see if it's not needed anymore. Let's test in Gitpod to make sure it works, and that the Tower docs still work with the mkdocs-material upgrade.