### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,3 @@
 * @evanfloden @pditommaso @drewdipalma @swampie @ewels @llewellyn-sl
+
+/docs/ @llewellyn-sl

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,2 @@
-* @evanfloden @pditommaso @drewdipalma @swampie @ewels @llewellyn-sl
 
 /docs/ @llewellyn-sl


### PR DESCRIPTION
Add /docs codeowner permission to prevent all code owners from getting notifications for every PR to master. 