### PR TITLE
Update overview.md - fix typo in documentation

### DIFF
--- a/docs/api/overview.md
+++ b/docs/api/overview.md
@@ -67,7 +67,7 @@ curl -H "Authorization: Bearer QH..E5M="
 
 ### Client errors
 
-There exists two typical standard errors, or non `200` or `204` status responses, to expect from the API.
+There exists two typical standard errors, or non `400` or `404` status responses, to expect from the API.
 
 ### Bad Request
 


### PR DESCRIPTION
I found two typos in the documentation. In the API overview, the error section documentation says about error codes 200 and 204. There should be certainly 400 and 404 codes. The PR fixes it.